### PR TITLE
EVDEV_SCALE removed which can be handled as a special case by EVDEV_CALIBRATE

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -186,10 +186,7 @@ bool evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
         return false;
     /*Store the collected data*/
 
-#if EVDEV_SCALE
-    data->point.x = map(evdev_root_x, 0, EVDEV_SCALE_HOR_RES, 0, lv_disp_get_hor_res(drv->disp));
-    data->point.y = map(evdev_root_y, 0, EVDEV_SCALE_VER_RES, 0, lv_disp_get_ver_res(drv->disp));
-#elif EVDEV_CALIBRATE
+#if EVDEV_CALIBRATE
     data->point.x = map(evdev_root_x, EVDEV_HOR_MIN, EVDEV_HOR_MAX, 0, lv_disp_get_hor_res(drv->disp));
     data->point.y = map(evdev_root_y, EVDEV_VER_MIN, EVDEV_VER_MAX, 0, lv_disp_get_ver_res(drv->disp));
 #else

--- a/lv_drv_conf_templ.h
+++ b/lv_drv_conf_templ.h
@@ -325,19 +325,14 @@
 #  define EVDEV_NAME   "/dev/input/event0"        /*You can use the "evtest" Linux tool to get the list of devices and test them*/
 #  define EVDEV_SWAP_AXES         0               /*Swap the x and y axes of the touchscreen*/
 
-#  define EVDEV_SCALE             0               /* Scale input, e.g. if touchscreen resolution does not match display resolution */
-#  if EVDEV_SCALE
-#    define EVDEV_SCALE_HOR_RES     (4096)          /* Horizontal resolution of touchscreen */
-#    define EVDEV_SCALE_VER_RES     (4096)          /* Vertical resolution of touchscreen */
-#  endif  /*EVDEV_SCALE*/
-
 #  define EVDEV_CALIBRATE         0               /*Scale and offset the touchscreen coordinates by using maximum and minimum values for each axis*/
+
 #  if EVDEV_CALIBRATE
-#    define EVDEV_HOR_MIN   3800                    /*If EVDEV_XXX_MIN > EVDEV_XXX_MAX the XXX axis is automatically inverted*/
-#    define EVDEV_HOR_MAX   200
-#    define EVDEV_VER_MIN   200
-#    define EVDEV_VER_MAX   3800
-#  endif  /*EVDEV_SCALE*/
+#    define EVDEV_HOR_MIN         0               /*to invert axis swap EVDEV_XXX_MIN by EVDEV_XXX_MAX*/
+#    define EVDEV_HOR_MAX      4096               /*"evtest" Linux tool can help to get the correct calibraion values>*/
+#    define EVDEV_VER_MIN         0
+#    define EVDEV_VER_MAX      4096
+#  endif  /*EVDEV_CALIBRATE*/
 #endif  /*USE_EVDEV*/
 
 /*-------------------------------


### PR DESCRIPTION
## reason for changing
`EVDEV_CALIBRATE` provides the more flexible functions (scale & invert the axis) than `EVDEV_SCALE`. Also the existence of these two parameters caused issues and PRs in the past.

## changes
**EVDEV_SCALE** was removed and the settings for calibration was set to the default values of **EVDEV_SCALE**. 

### unwanted changes in functionality
If a project is using `EVDEV_SCALE` the scaling will simply not working without any notice to the user during build. But changing to `EVDEV_CALIBRATE` will restore the functionality.

## calibration hints
The previously used settings for `EVDEV_CALIBRATE` corresponds to typical 3.5 LCD touch panel used for a Raspberry PI operating in 180 degree screen rotation (`EVDEV_HOR_MIN` > `EVDEV_HOR_MAX`):

```c
#define EVDEV_HOR_MIN      3800
#define EVDEV_HOR_MAX       200
#define EVDEV_VER_MIN       200
#define EVDEV_VER_MAX      3800
```