### PR TITLE
Use wildcard function instead of find.

### DIFF
--- a/lv_drivers.mk
+++ b/lv_drivers.mk
@@ -1,1 +1,7 @@
-CSRCS += $(shell find -L lv_drivers -name \*.c)
+LV_DRIVERS_DIR_NAME ?= lv_drivers
+
+CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/*.c)
+CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/indev/*.c)
+CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/gtk/*.c)
+CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/display/*.c)
+


### PR DESCRIPTION
This fix uses the wildcard function instead of find because it allows to use other subdirectories for building.