### PR TITLE
Fix wildcard matching in lv_drivers.mk

### DIFF
--- a/lv_drivers.mk
+++ b/lv_drivers.mk
@@ -2,6 +2,6 @@ LV_DRIVERS_DIR_NAME ?= lv_drivers
 
 CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/*.c)
 CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/indev/*.c)
-CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/gtk/*.c)
+CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/gtkdrv/*.c)
 CSRCS += $(wildcard $(LVGL_DIR)/$(LV_DRIVERS_DIR_NAME)/display/*.c)
 


### PR DESCRIPTION
233860e introduced wildcard matching for sources in lv_drivers.mk,
but also introduced a typo, so gtkdrv/ directory was ignored and
non-existent gtk/ was searched. This resulted in linking error for
all programs using GTK as their display driver because gtkdrv/gtkdrv.c
wasn't compiled, which means that important symbols like gtkdrv_init
and gtkdrv_flush_cb weren't created.