### PR TITLE
fbdev: add functions for getting screen resolution

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -236,6 +236,14 @@ void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color
     lv_disp_flush_ready(drv);
 }
 
+void fbdev_get_sizes(uint32_t *width, uint32_t *height) {
+    if (width)
+        *width = vinfo.xres;
+
+    if (height)
+        *height = vinfo.yres;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/display/fbdev.h
+++ b/display/fbdev.h
@@ -43,6 +43,7 @@ extern "C" {
 void fbdev_init(void);
 void fbdev_exit(void);
 void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
+void fbdev_get_sizes(uint32_t *width, uint32_t *height);
 
 
 /**********************


### PR DESCRIPTION
This can be used for creating generic app where you don't know what screen resolution user will have.