### PR TITLE
ILI9341: No longer including lv_hal_disp.h.

### DIFF
--- a/display/ILI9341.c
+++ b/display/ILI9341.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <stdbool.h>
-#include "lvgl/src/lv_hal/lv_hal_disp.h"
 #include LV_DRV_DISP_INCLUDE
 #include LV_DRV_DELAY_INCLUDE
 


### PR DESCRIPTION
This header does not seem to be necessary and the build
was failing with the following error using platformio and
LVGL 7.7.0.

```
lib/lv_drivers/display/ILI9341.c: At top level:
lib/lv_drivers/display/ILI9341.c:22:10:
  fatal error: lvgl/src/lv_hal/lv_hal_disp.h: No such file or directory
 #include "lvgl/src/lv_hal/lv_hal_disp.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/esp32/lib9fb/lv_drivers/display/ILI9341.o] Error 1
```