### PR TITLE
Windows should not overlap when MONITOR_ZOOM > 1 and MONITOR_DUAL = 1 

### DIFF
--- a/display/monitor.c
+++ b/display/monitor.c
@@ -274,8 +274,8 @@ static void monitor_sdl_init(void)
     window_create(&monitor2);
     int x, y;
     SDL_GetWindowPosition(monitor2.window, &x, &y);
-    SDL_SetWindowPosition(monitor.window, x + MONITOR_HOR_RES / 2 + 10, y);
-    SDL_SetWindowPosition(monitor2.window, x - MONITOR_HOR_RES / 2 - 10, y);
+    SDL_SetWindowPosition(monitor.window, x + (MONITOR_HOR_RES * MONITOR_ZOOM) / 2 + 10, y);
+    SDL_SetWindowPosition(monitor2.window, x - (MONITOR_HOR_RES * MONITOR_ZOOM) / 2 - 10, y);
 #endif
 
     sdl_inited = true;


### PR DESCRIPTION
Quick fix to overlapping SDL windows when MONITOR_DUAL enabled and MONITOR_ZOOM greater than 1.