### PR TITLE
Fix "clicking" on MT touchscreens.

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -158,6 +158,11 @@ bool evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
                                 #else
                                         evdev_root_y = in.value;
                                 #endif
+            else if(in.code == ABS_MT_TRACKING_ID)
+                                if(in.value == -1)
+                                    evdev_button = LV_INDEV_STATE_REL;
+                                else if(in.value == 0)
+                                    evdev_button = LV_INDEV_STATE_PR;
         } else if(in.type == EV_KEY) {
             if(in.code == BTN_MOUSE || in.code == BTN_TOUCH) {
                 if(in.value == 0)


### PR DESCRIPTION
In linux kernel multi touch touchscreen drivers may not provide EV_KEYs events, and provide only ABS_MT_TRACKING_ID. This is very basic implementation, it is still single touch, but it allows to use those touchscreens.  