### PR TITLE
Add initial CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(GLOB_RECURSE SOURCES ./*.c)
+add_library(lv_drivers STATIC ${SOURCES})

--- a/win32drv/win32drv.h
+++ b/win32drv/win32drv.h
@@ -14,7 +14,7 @@
 #ifdef LV_CONF_INCLUDE_SIMPLE
 #include "lv_drv_conf.h"
 #else
-#include "../lv_drv_conf.h"
+#include "../../lv_drv_conf.h"
 #endif
 #endif
 


### PR DESCRIPTION
Added a primitive CMake file to build a library. Actually globbing is not ideal (see [here](https://stackoverflow.com/questions/1027247/is-it-better-to-specify-source-files-with-glob-or-each-file-individually-in-cmak/1060061) but it can be improved later by swapping with explicit source filenames.

I'm doing this to build the SDL simulator in Windows. I'll detail it on its own PR.

Also fixes a wrong include path.