### PR TITLE
Add LVGL v8 support for the new native Windows driver (win32drv)

### DIFF
--- a/win32drv/win32drv.c
+++ b/win32drv/win32drv.c
@@ -99,8 +99,13 @@ static LRESULT CALLBACK lv_win32_window_message_callback(
     WPARAM wParam,
     LPARAM lParam);
 
+#if LV_VERSION_CHECK(8, 0, 0)
+static void lv_win32_message_handler(
+    lv_timer_t* param);
+#else
 static void lv_win32_message_handler(
     lv_task_t* param);
+#endif
 
 /**********************
  *  GLOBAL VARIABLES
@@ -204,7 +209,11 @@ EXTERN_C bool lv_win32_init(
         return false;
     }
 
+#if LV_VERSION_CHECK(8, 0, 0)
+    lv_timer_create(lv_win32_message_handler, 0, NULL);
+#else
     lv_task_create(lv_win32_message_handler, 0, LV_TASK_PRIO_HIGHEST, NULL);
+#endif
 
     lv_win32_enable_child_window_dpi_message(g_window_handle);
 
@@ -218,6 +227,41 @@ EXTERN_C bool lv_win32_init(
     DeleteDC(g_buffer_dc_handle);
     g_buffer_dc_handle = hNewBufferDC;
 
+#if LV_VERSION_CHECK(8, 0, 0)
+    static lv_disp_draw_buf_t disp_buf;
+    lv_disp_draw_buf_init(
+        &disp_buf,
+        (lv_color_t*)malloc(hor_res * ver_res * sizeof(lv_color_t)),
+        NULL,
+        hor_res * ver_res);
+
+    static lv_disp_drv_t disp_drv;
+    lv_disp_drv_init(&disp_drv);
+    disp_drv.hor_res = hor_res;
+    disp_drv.ver_res = ver_res;
+    disp_drv.flush_cb = lv_win32_display_driver_flush_callback;
+    disp_drv.draw_buf = &disp_buf;
+    disp_drv.rounder_cb = lv_win32_display_driver_rounder_callback;
+    g_display = lv_disp_drv_register(&disp_drv);
+
+    static lv_indev_drv_t indev_drv;
+    lv_indev_drv_init(&indev_drv);
+    indev_drv.type = LV_INDEV_TYPE_POINTER;
+    indev_drv.read_cb = lv_win32_mouse_driver_read_callback;
+    lv_indev_drv_register(&indev_drv);
+
+    static lv_indev_drv_t kb_drv;
+    lv_indev_drv_init(&kb_drv);
+    kb_drv.type = LV_INDEV_TYPE_KEYPAD;
+    kb_drv.read_cb = lv_win32_keyboard_driver_read_callback;
+    lv_indev_drv_register(&kb_drv);
+
+    static lv_indev_drv_t enc_drv;
+    lv_indev_drv_init(&enc_drv);
+    enc_drv.type = LV_INDEV_TYPE_ENCODER;
+    enc_drv.read_cb = lv_win32_mousewheel_driver_read_callback;
+    lv_indev_drv_register(&enc_drv);
+#else
     static lv_disp_buf_t disp_buf;
     lv_disp_buf_init(
         &disp_buf,
@@ -251,6 +295,7 @@ EXTERN_C bool lv_win32_init(
     enc_drv.type = LV_INDEV_TYPE_ENCODER;
     enc_drv.read_cb = lv_win32_mousewheel_driver_read_callback;
     lv_indev_drv_register(&enc_drv);
+#endif
 
     ShowWindow(g_window_handle, show_window_mode);
     UpdateWindow(g_window_handle);
@@ -547,8 +592,13 @@ static LRESULT CALLBACK lv_win32_window_message_callback(
         RECT ClientRect;
         GetClientRect(hWnd, &ClientRect);
 
+#if LV_VERSION_CHECK(8, 0, 0)
+        int WindowWidth = g_display->driver->hor_res;
+        int WindowHeight = g_display->driver->ver_res;
+#else
         int WindowWidth = g_display->driver.hor_res;
         int WindowHeight = g_display->driver.ver_res;
+#endif
 
         SetWindowPos(
             hWnd,
@@ -571,8 +621,13 @@ static LRESULT CALLBACK lv_win32_window_message_callback(
     return 0;
 }
 
+#if LV_VERSION_CHECK(8, 0, 0)
+static void lv_win32_message_handler(
+    lv_timer_t* param)
+#else
 static void lv_win32_message_handler(
     lv_task_t* param)
+#endif
 {
     UNREFERENCED_PARAMETER(param);
 


### PR DESCRIPTION
I have said "I try to adapt lv_sim_visual_studio to v8, and the new UI make me feel impressive about that." in https://github.com/lvgl/lvgl/issues/2144#issuecomment-814718718.

I don't think I can migrate the lv_sim_visual_studio to LVGL v8 even in the new "dev" branch, because many examples in lv_examples repo can't be compiled without error.

But I think I can add the LVGL v8 support for the new native Windows driver (win32drv) because it looks stable enough.

Note: This driver still supports v7. (I use the LV_VERSION_CHECK macro for determining the LVGL version.)