### PR TITLE
evdev should not use the lv_disp_get_hor_res function

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -212,8 +212,8 @@ bool evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
     /*Store the collected data*/
 
 #if EVDEV_CALIBRATE
-    data->point.x = map(evdev_root_x, EVDEV_HOR_MIN, EVDEV_HOR_MAX, 0, lv_disp_get_hor_res(drv->disp));
-    data->point.y = map(evdev_root_y, EVDEV_VER_MIN, EVDEV_VER_MAX, 0, lv_disp_get_ver_res(drv->disp));
+    data->point.x = map(evdev_root_x, EVDEV_HOR_MIN, EVDEV_HOR_MAX, 0, drv->disp->driver.hor_res);
+    data->point.y = map(evdev_root_y, EVDEV_VER_MIN, EVDEV_VER_MAX, 0, drv->disp->driver.ver_res);
 #else
     data->point.x = evdev_root_x;
     data->point.y = evdev_root_y;
@@ -225,10 +225,10 @@ bool evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
       data->point.x = 0;
     if(data->point.y < 0)
       data->point.y = 0;
-    if(data->point.x >= lv_disp_get_hor_res(drv->disp))
-      data->point.x = lv_disp_get_hor_res(drv->disp) - 1;
-    if(data->point.y >= lv_disp_get_ver_res(drv->disp))
-      data->point.y = lv_disp_get_ver_res(drv->disp) - 1;
+    if(data->point.x >= drv->disp->driver.hor_res)
+      data->point.x = drv->disp->driver.hor_res - 1;
+    if(data->point.y >= drv->disp->driver.ver_res)
+      data->point.y = drv->disp->driver.ver_res - 1;
 
     return false;
 }


### PR DESCRIPTION
If we rotate the screen 90 degrees or 270 degrees
it will use the wrong width and height to process the touch screen data