### PR TITLE
Fix window size issue for the new native Windows driver (win32drv)

### DIFF
--- a/win32drv/win32drv.c
+++ b/win32drv/win32drv.c
@@ -176,9 +176,9 @@ EXTERN_C bool lv_win32_init(
     RECT NewWindowSize;
 
     NewWindowSize.left = 0;
-    NewWindowSize.right = hor_res * WIN32DRV_MONITOR_ZOOM - 1;
+    NewWindowSize.right = hor_res * WIN32DRV_MONITOR_ZOOM;
     NewWindowSize.top = 0;
-    NewWindowSize.bottom = ver_res * WIN32DRV_MONITOR_ZOOM - 1;
+    NewWindowSize.bottom = ver_res * WIN32DRV_MONITOR_ZOOM;
 
     AdjustWindowRectEx(
         &NewWindowSize,
@@ -605,8 +605,8 @@ static LRESULT CALLBACK lv_win32_window_message_callback(
             NULL,
             SuggestedRect->left,
             SuggestedRect->top,
-            SuggestedRect->right + (WindowWidth - 1 - ClientRect.right),
-            SuggestedRect->bottom + (WindowHeight - 1 - ClientRect.bottom),
+            SuggestedRect->right + (WindowWidth - ClientRect.right),
+            SuggestedRect->bottom + (WindowHeight - ClientRect.bottom),
             SWP_NOZORDER | SWP_NOACTIVATE);
 
         break;


### PR DESCRIPTION
# Example from @FASTSHIFT
```
    lv_obj_t* obj = lv_obj_create(lv_scr_act());
    lv_obj_remove_style_all(obj);
    lv_obj_set_pos(obj, 0, 0);
    lv_obj_set_size(obj, LV_HOR_RES, LV_VER_RES);
    lv_obj_set_style_border_color(obj, lv_color_red(), 0);
    lv_obj_set_style_border_width(obj, 1, 0);
```

# Before
![image](https://user-images.githubusercontent.com/10867563/116044224-40161080-a6a3-11eb-9153-efa9c69c532f.png)

# After
![image](https://user-images.githubusercontent.com/10867563/116044242-460bf180-a6a3-11eb-859d-a4c590dfc70e.png)
