### PR TITLE
Add Windows touch input support for the new native Windows driver (win32drv)

### DIFF
--- a/win32drv/win32drv.c
+++ b/win32drv/win32drv.c
@@ -176,9 +176,9 @@ EXTERN_C bool lv_win32_init(
     RECT NewWindowSize;
 
     NewWindowSize.left = 0;
-    NewWindowSize.right = hor_res * WIN32DRV_MONITOR_ZOOM - 1;
+    NewWindowSize.right = hor_res * WIN32DRV_MONITOR_ZOOM;
     NewWindowSize.top = 0;
-    NewWindowSize.bottom = ver_res * WIN32DRV_MONITOR_ZOOM - 1;
+    NewWindowSize.bottom = ver_res * WIN32DRV_MONITOR_ZOOM;
 
     AdjustWindowRectEx(
         &NewWindowSize,
@@ -605,8 +605,8 @@ static LRESULT CALLBACK lv_win32_window_message_callback(
             NULL,
             SuggestedRect->left,
             SuggestedRect->top,
-            SuggestedRect->right + (WindowWidth - 1 - ClientRect.right),
-            SuggestedRect->bottom + (WindowHeight - 1 - ClientRect.bottom),
+            SuggestedRect->right + (WindowWidth - ClientRect.right),
+            SuggestedRect->bottom + (WindowHeight - ClientRect.bottom),
             SWP_NOZORDER | SWP_NOACTIVATE);
 
         break;


### PR DESCRIPTION
Backported from https://github.com/lvgl/lv_port_windows.

For improve the experience when using touch devices such as Surface tablets, Wacom pen tablets and etc.

P.S. I want to remove LVGL v7 support for win32drv in the next pull request, for focusing on LVGL v8 simulator improvements and more compact implementations.

Kenji Mouri