### PR TITLE
Add input drivers to the default group for the new native Windows driver (win32drv)

### DIFF
--- a/win32drv/win32drv.c
+++ b/win32drv/win32drv.c
@@ -164,6 +164,7 @@ static UINT32* g_pixel_buffer = NULL;
 static SIZE_T g_pixel_buffer_size = 0;
 
 static lv_disp_t* g_display = NULL;
+static lv_group_t* g_default_group = NULL;
 
 static bool volatile g_mouse_pressed = false;
 static LPARAM volatile g_mouse_value = 0;
@@ -280,23 +281,26 @@ EXTERN_C bool lv_win32_init(
     disp_drv.rounder_cb = lv_win32_display_driver_rounder_callback;
     g_display = lv_disp_drv_register(&disp_drv);
 
+    g_default_group = lv_group_create();
+    lv_group_set_default(g_default_group);
+
     static lv_indev_drv_t indev_drv;
     lv_indev_drv_init(&indev_drv);
     indev_drv.type = LV_INDEV_TYPE_POINTER;
     indev_drv.read_cb = lv_win32_mouse_driver_read_callback;
-    lv_indev_drv_register(&indev_drv);
+    lv_indev_set_group(lv_indev_drv_register(&indev_drv), g_default_group);
 
     static lv_indev_drv_t kb_drv;
     lv_indev_drv_init(&kb_drv);
     kb_drv.type = LV_INDEV_TYPE_KEYPAD;
     kb_drv.read_cb = lv_win32_keyboard_driver_read_callback;
-    lv_indev_drv_register(&kb_drv);
+    lv_indev_set_group(lv_indev_drv_register(&kb_drv), g_default_group);
 
     static lv_indev_drv_t enc_drv;
     lv_indev_drv_init(&enc_drv);
     enc_drv.type = LV_INDEV_TYPE_ENCODER;
     enc_drv.read_cb = lv_win32_mousewheel_driver_read_callback;
-    lv_indev_drv_register(&enc_drv);
+    lv_indev_set_group(lv_indev_drv_register(&enc_drv), g_default_group);
 
     ShowWindow(g_window_handle, show_window_mode);
     UpdateWindow(g_window_handle);

--- a/win32drv/win32drv.c
+++ b/win32drv/win32drv.c
@@ -189,12 +189,31 @@ static WPARAM volatile g_keyboard_value = 0;
 EXTERN_C void lv_win32_add_all_input_devices_to_group(
     lv_group_t* group)
 {
-    if (group)
+    if (!group)
     {
-        lv_indev_set_group(lv_win32_pointer_device_object, group);
-        lv_indev_set_group(lv_win32_keypad_device_object, group);
-        lv_indev_set_group(lv_win32_encoder_device_object, group);
+        LV_LOG_WARN(
+            "The group object is NULL. Get the default group object instead.");
+
+        group = lv_group_get_default();
+        if (!group)
+        {
+            LV_LOG_WARN(
+                "The default group object is NULL. Create a new group object "
+                "and set it to default instead.");
+
+            group = lv_group_create();
+            if (group)
+            {
+                lv_group_set_default(group);
+            }
+        }
     }
+
+    LV_ASSERT_MSG(group, "Cannot obtain an available group object.");
+
+    lv_indev_set_group(lv_win32_pointer_device_object, group);
+    lv_indev_set_group(lv_win32_keypad_device_object, group);
+    lv_indev_set_group(lv_win32_encoder_device_object, group);
 }
 
 EXTERN_C bool lv_win32_init(

--- a/win32drv/win32drv.h
+++ b/win32drv/win32drv.h
@@ -56,6 +56,13 @@
 
 EXTERN_C bool lv_win32_quit_signal;
 
+EXTERN_C lv_indev_t* lv_win32_pointer_device_object;
+EXTERN_C lv_indev_t* lv_win32_keypad_device_object;
+EXTERN_C lv_indev_t* lv_win32_encoder_device_object;
+
+EXTERN_C void lv_win32_add_all_input_devices_to_group(
+    lv_group_t* group);
+
 EXTERN_C bool lv_win32_init(
     HINSTANCE instance_handle,
     int show_window_mode,


### PR DESCRIPTION
For solving "Still no keyboard and mouse." mentioned in https://github.com/lvgl/lv_sim_codeblocks_win/issues/16#issuecomment-875141993.