### PR TITLE
Fix the color issue when enable LV_COLOR_16_SWAP for the new native Windows driver (win32drv)

### DIFF
--- a/win32drv/win32drv.c
+++ b/win32drv/win32drv.c
@@ -660,11 +660,23 @@ static void lv_win32_display_driver_flush_callback(
     lv_color_t* color_p)
 {
 #if (LV_COLOR_DEPTH == 32) || \
-    (LV_COLOR_DEPTH == 16) || \
+    (LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP == 0) || \
     (LV_COLOR_DEPTH == 8) || \
     (LV_COLOR_DEPTH == 1)
     UNREFERENCED_PARAMETER(area);
     memcpy(g_pixel_buffer, color_p, g_pixel_buffer_size);
+#elif (LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP != 0)
+    SIZE_T count = g_pixel_buffer_size / sizeof(UINT16);
+    PUINT16 source = (PUINT16)color_p;
+    PUINT16 destination = (PUINT16)g_pixel_buffer;
+    for (SIZE_T i = 0; i < count; ++i)
+    {
+        UINT16 current = *source;
+        *destination = (LOBYTE(current) << 8) | HIBYTE(current);
+
+        ++source;
+        ++destination;
+    }
 #else
     for (int y = area->y1; y <= area->y2; ++y)
     {


### PR DESCRIPTION
Reported by @FASTSHIFT.

## Before
![image](https://user-images.githubusercontent.com/10867563/128728372-2291823c-fb91-4aa9-8149-87de125d145e.png)

## After
![image](https://user-images.githubusercontent.com/10867563/128729771-0c44974f-9c9e-48b0-a0cb-bbc57d1048ef.png)
