### PR TITLE
fbdev: unblank the device during initialization

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -90,6 +90,12 @@ void fbdev_init(void)
     }
     printf("The framebuffer device was opened successfully.\n");
 
+    // Make sure that the display is on.
+    if (ioctl(fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
+        perror("ioctl(FBIOBLANK)");
+        return;
+    }
+
 #if USE_BSD_FBDEV
     struct fbtype fb;
     unsigned line_length;


### PR DESCRIPTION
Make sure the connector/device is unblanked so that graphics are
actually displayed.

Signed-off-by: Leif Middelschulte <Leif.Middelschulte@klsmartin.com>