### PR TITLE
fbdev: fixup BLANK macro usage on FreeBSD

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -76,6 +76,10 @@ static int fbfd = 0;
  *      MACROS
  **********************/
 
+#if USE_BSD_FBDEV
+#define FBIOBLANK FBIO_BLANK
+#endif /* USE_BSD_FBDEV */
+
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/


### PR DESCRIPTION
The FreeBSD macro's name contains an underscore.

This fix was suggested [0] by @thelunatic.

[0] https://github.com/lvgl/lv_drivers/pull/142#issuecomment-896125290