### PR TITLE
fix(ILI9341) Remove 'const' qualifier on 3rd argument of 'ili9341_flush'

### DIFF
--- a/display/ILI9341.c
+++ b/display/ILI9341.c
@@ -331,7 +331,7 @@ void ili9341_init(void)
     LV_DRV_DELAY_MS(20);
 }
 
-void ili9341_flush(lv_disp_drv_t * drv, const lv_area_t * area, const lv_color_t * color_p)
+void ili9341_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p)
 {
     if(area->x2 < 0 || area->y2 < 0 || area->x1 > (ILI9341_HOR_RES - 1) || area->y1 > (ILI9341_VER_RES - 1)) {
         lv_disp_flush_ready(drv);

--- a/display/ILI9341.h
+++ b/display/ILI9341.h
@@ -52,7 +52,7 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 void ili9341_init(void);
-void ili9341_flush(lv_disp_drv_t * drv, const lv_area_t * area, const lv_color_t * color_p);
+void ili9341_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
 void ili9341_rotate(int degrees, bool bgr);
 /**********************
  *      MACROS


### PR DESCRIPTION

This fixes the following compilation warning:

warning: assignment to ‘void (*)(struct _lv_disp_drv_t *, const lv_area_t *, lv_color_t *)’ {aka ‘void (*)(struct _lv_disp_drv_t *, const struct <anonymous> *, union <anonymous> *)’} from incompatible pointer type ‘void (*)(lv_disp_drv_t *, const lv_area_t *, const lv_color_t *)’ {aka ‘void (*)(struct _lv_disp_drv_t *, const struct <anonymous> *, const union <anonymous> *)’} [-Wincompatible-pointer-types]
   54 |  disp_drv.flush_cb = ili9341_flush;
      |                    ^

Signed-off-by: Derald D. Woods <woods.technical@gmail.com>