### PR TITLE
Make use of SDL_TEXTINPUT for keyboard input

### DIFF
--- a/indev/keyboard.c
+++ b/indev/keyboard.c
@@ -12,6 +12,9 @@
 /*********************
  *      DEFINES
  *********************/
+#ifndef KEYBOARD_BUFFER_SIZE
+#define KEYBOARD_BUFFER_SIZE SDL_TEXTINPUTEVENT_TEXT_SIZE
+#endif
 
 /**********************
  *      TYPEDEFS
@@ -25,7 +28,7 @@ static uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static char buf[SDL_TEXTINPUTEVENT_TEXT_SIZE];
+static char buf[KEYBOARD_BUFFER_SIZE];
 
 /**********************
  *      MACROS
@@ -82,15 +85,21 @@ void keyboard_handler(SDL_Event * event)
         case SDL_KEYDOWN:                       /*Button press*/
             {
                 const uint32_t ctrl_key = keycode_to_ctrl_key(event->key.keysym.sym);
-                if (ctrl_key != '\0') {
-                    const size_t len = strlen(buf);
+                if (ctrl_key == '\0')
+                    return;
+                const size_t len = strlen(buf);
+                if (len < KEYBOARD_BUFFER_SIZE - 1) {
                     buf[len] = ctrl_key;
                     buf[len + 1] = '\0';
                 }
                 break;
             }
         case SDL_TEXTINPUT:                     /*Text input*/
-            strcat(buf, event->text.text);
+            {
+                const size_t len = strlen(buf) + strlen(event->text.text);
+                if (len < KEYBOARD_BUFFER_SIZE - 1)
+                    strcat(buf, event->text.text);
+            }
             break;
         default:
             break;


### PR DESCRIPTION
Minor changes to the keyboard input driver allow for more fluent typing than before. Instead of a single key stroke the code now utilizes SDLs own [SDL_TextInputEvent](https://wiki.libsdl.org/SDL_TextInputEvent) to read up to 32 characters at the time into a local buffer. This buffer is then red by LVGLs read_cb callback by setting the _continue_reading_ flag in the _lv_indev_data_t_ parameter until empty.