### PR TITLE
Added missing '\t' to SDL -> LVGL key conversion

### DIFF
--- a/indev/keyboard.c
+++ b/indev/keyboard.c
@@ -147,6 +147,7 @@ static uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key)
         case '\r':
             return LV_KEY_ENTER;
 
+        case SDLK_TAB:
         case SDLK_PAGEDOWN:
             return LV_KEY_NEXT;
 


### PR DESCRIPTION
Missing '\t' (SDLK_TAB) key in the SDL to LVGL key conversion didn't allow the focus to move between widgets when pressing tab.