### PR TITLE
Add support for keypads to libinput driver

### DIFF
--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 #endif
 
-#if USE_LIBINPUT
+#if USE_LIBINPUT || USE_BSD_LIBINPUT
 
 #ifdef LV_LVGL_H_INCLUDE_SIMPLE
 #include "lvgl.h"
@@ -56,16 +56,15 @@ bool libinput_set_file(char* dev_name);
  * Get the current position and state of the libinput
  * @param indev_drv driver object itself
  * @param data store the libinput data here
- * @return false: because the points are not buffered, so no more data to be read
  */
-bool libinput_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
+void libinput_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
 
 
 /**********************
  *      MACROS
  **********************/
 
-#endif /* USE_LIBINPUT */
+#endif /* USE_LIBINPUT || USE_BSD_LIBINPUT */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -372,15 +372,19 @@
 #endif
 
 /*-------------------------------------------------
- * Touchscreen as libinput interface (for Linux based systems)
+ * Touchscreen or keyboard as libinput interface (for Linux based systems)
  *------------------------------------------------*/
 #ifndef USE_LIBINPUT
 #  define USE_LIBINPUT           0
 #endif
 
-#if USE_LIBINPUT
+#ifndef USE_BSD_LIBINPUT
+#  define USE_BSD_LIBINPUT       0
+#endif
+
+#if USE_LIBINPUT || USE_BSD_LIBINPUT
 #  define LIBINPUT_NAME   "/dev/input/event0"        /*You can use the "evtest" Linux tool to get the list of devices and test them*/
-#endif  /*USE_LIBINPUT*/
+#endif  /*USE_LIBINPUT || USE_BSD_LIBINPUT*/
 
 /*-------------------------------------------------
  * Mouse or touchpad as evdev interface (for Linux based systems)


### PR DESCRIPTION
This allows to use keyboard / keypad devices with the libinput driver.

The implementation is largely analogous to the existing keypad support in the evdev driver. Unfortunately, I had to introduce a `USE_BSD_LIBINPUT` macro (again, analogous to the evdev driver) in order to get the right include path based on the system type.

Note that this touches the same file as #150 so one of the PRs will have to be rebased after the other is merged (if any of them is merged that is :crossed_fingers:  :slightly_smiling_face:).