### PR TITLE
Automatic device discovery via libinput

### DIFF
--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <poll.h>
+#include <dirent.h>
 #include <libinput.h>
 
 #if USE_BSD_LIBINPUT
@@ -31,18 +32,30 @@
 /**********************
  *      TYPEDEFS
  **********************/
+struct input_device {
+  libinput_capability capabilities;
+  char *path;
+};
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+static bool rescan_devices(void);
+static bool add_scanned_device(char *path, libinput_capability capabilities);
+static void reset_scanned_devices(void);
+
 static void read_pointer(struct libinput_event *event);
 static void read_keypad(struct libinput_event *event);
+
 static int open_restricted(const char *path, int flags, void *user_data);
 static void close_restricted(int fd, void *user_data);
 
 /**********************
  *  STATIC VARIABLES
  **********************/
+static struct input_device *devices = NULL;
+static size_t num_devices = 0;
+
 static int libinput_fd;
 static int libinput_button;
 static int libinput_key_val;
@@ -65,6 +78,45 @@ static const struct libinput_interface interface = {
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
+
+/**
+ * find connected input device with specific capabilities
+ * @param capabilities required device capabilities
+ * @param force_rescan erase the device cache (if any) and rescan the file system for available devices
+ * @return device node path (e.g. /dev/input/event0) for the first matching device or NULL if no device was found.
+ *         The pointer is safe to use until the next forceful device search.
+ */
+char *libinput_find_dev(libinput_capability capabilities, bool force_rescan) {
+  char *path = NULL;
+  libinput_find_devs(capabilities, &path, 1, force_rescan);
+  return path;
+}
+
+/**
+ * find connected input devices with specific capabilities
+ * @param capabilities required device capabilities
+ * @param devices pre-allocated array to store the found device node paths (e.g. /dev/input/event0). The pointers are
+ *                safe to use until the next forceful device search.
+ * @param count maximum number of devices to find (the devices array should be at least this long)
+ * @param force_rescan erase the device cache (if any) and rescan the file system for available devices
+ * @return number of devices that were found
+ */
+size_t libinput_find_devs(libinput_capability capabilities, char **found, size_t count, bool force_rescan) {
+  if ((!devices || force_rescan) && !rescan_devices()) {
+    return 0;
+  }
+
+  size_t num_found = 0;
+
+  for (size_t i = 0; i < num_devices && num_found < count; ++i) {
+    if (devices[i].capabilities & capabilities) {
+      found[num_found] = devices[i].path;
+      num_found++;
+    }
+  }
+
+  return num_found;
+}
 
 /**
  * reconfigure the device file for libinput
@@ -106,8 +158,10 @@ void libinput_init(void)
 {
   libinput_device = NULL;
   libinput_context = libinput_path_create_context(&interface, NULL);
-  if(!libinput_set_file(LIBINPUT_NAME)) {
-      perror("unable to add device \"" LIBINPUT_NAME "\" to libinput context:");
+
+  const char *path = LIBINPUT_NAME;
+  if(path == NULL || !libinput_set_file(path)) {
+      fprintf(stderr, "unable to add device \"%s\" to libinput context: %s\n", path ? path : "NULL", strerror(errno));
       return;
   }
   libinput_fd = libinput_get_fd(libinput_context);
@@ -162,6 +216,121 @@ report_most_recent_state:
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+/**
+ * rescan all attached evdev devices and store capable ones into the static devices array for quick later filtering
+ * @return true if the operation succeeded
+ */
+static bool rescan_devices(void) {
+  reset_scanned_devices();
+
+  DIR *dir;
+  struct dirent *ent;
+  if (!(dir = opendir("/dev/input"))) {
+    perror("unable to open directory /dev/input");
+    return false;
+  }
+
+  struct libinput *context = libinput_path_create_context(&interface, NULL);
+
+  while ((ent = readdir(dir))) {
+    if (strncmp(ent->d_name, "event", 5) != 0) {
+      continue;
+    }
+
+    char *path = malloc((11 + strlen(ent->d_name)) * sizeof(char));
+    if (!path) {
+      perror("could not allocate memory for device node path");
+      libinput_unref(context);
+      reset_scanned_devices();
+      return false;
+    }
+    strcpy(path, "/dev/input/");
+    strcat(path, ent->d_name);
+
+    struct libinput_device *device = libinput_path_add_device(context, path);
+    if(!device) {
+      perror("unable to add device to libinput context");
+      free(path);
+      continue;
+    }
+
+    /* The device pointer is guaranteed to be valid until the next libinput_dispatch. Since we're not dispatching events
+     * as part of this function, we don't have to increase its reference count to keep it alive.
+     * https://wayland.freedesktop.org/libinput/doc/latest/api/group__base.html#gaa797496f0150b482a4e01376bd33a47b */
+
+    libinput_capability capabilities = LIBINPUT_CAPABILITY_NONE;
+    if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_KEYBOARD)
+        && (libinput_device_keyboard_has_key(device, KEY_ENTER) || libinput_device_keyboard_has_key(device, KEY_KPENTER)))
+    {
+      capabilities |= LIBINPUT_CAPABILITY_KEYBOARD;
+    }
+    if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_POINTER)) {
+      capabilities |= LIBINPUT_CAPABILITY_POINTER;
+    }
+    if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_TOUCH)) {
+      capabilities |= LIBINPUT_CAPABILITY_TOUCH;
+    }
+
+    libinput_path_remove_device(device);
+
+    if (capabilities == LIBINPUT_CAPABILITY_NONE) {
+      free(path);
+      continue;
+    }
+
+    if (!add_scanned_device(path, capabilities)) {
+      free(path);
+      libinput_unref(context);
+      reset_scanned_devices();
+      return false;
+    }
+  }
+
+  libinput_unref(context);
+  return true;
+}
+
+/**
+ * add a new scanned device to the static devices array, growing its size when necessary
+ * @param path device file path
+ * @param capabilities device input capabilities
+ * @return true if the operation succeeded
+ */
+static bool add_scanned_device(char *path, libinput_capability capabilities) {
+  /* Double array size every 2^n elements */
+  if ((num_devices & (num_devices + 1)) == 0) {
+      struct input_device *tmp = realloc(devices, (2 * num_devices + 1) * sizeof(struct input_device));
+      if (!tmp) {
+        perror("could not reallocate memory for devices array");
+        return false;
+      }
+      devices = tmp;
+  }
+
+  devices[num_devices].path = path;
+  devices[num_devices].capabilities = capabilities;
+  num_devices++;
+
+  return true;
+}
+
+/**
+ * reset the array of scanned devices and free any dynamically allocated memory
+ */
+static void reset_scanned_devices(void) {
+  if (!devices) {
+    return;
+  }
+
+  for (int i = 0; i < num_devices; ++i) {
+    free(devices[i].path);
+  }
+  free(devices);
+
+  devices = NULL;
+  num_devices = 0;
+}
 
 /**
  * Handle libinput touch / pointer events

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -36,11 +36,35 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+typedef enum {
+  LIBINPUT_CAPABILITY_NONE     = 0,
+  LIBINPUT_CAPABILITY_KEYBOARD = 1U << 0,
+  LIBINPUT_CAPABILITY_POINTER  = 1U << 1,
+  LIBINPUT_CAPABILITY_TOUCH    = 1U << 2
+} libinput_capability;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * find connected input device with specific capabilities
+ * @param capabilities required device capabilities
+ * @param force_rescan erase the device cache (if any) and rescan the file system for available devices
+ * @return device node path (e.g. /dev/input/event0) for the first matching device or NULL if no device was found.
+ *         The pointer is safe to use until the next forceful device search.
+ */
+char *libinput_find_dev(libinput_capability capabilities, bool force_rescan);
+/**
+ * find connected input devices with specific capabilities
+ * @param capabilities required device capabilities
+ * @param devices pre-allocated array to store the found device node paths (e.g. /dev/input/event0). The pointers are
+ *                safe to use until the next forceful device search.
+ * @param count maximum number of devices to find (the devices array should be at least this long)
+ * @param force_rescan erase the device cache (if any) and rescan the file system for available devices
+ * @return number of devices that were found
+ */
+size_t libinput_find_devs(libinput_capability capabilities, char **found, size_t count, bool force_rescan);
 /**
  * Initialize the libinput
  */

--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -383,7 +383,10 @@
 #endif
 
 #if USE_LIBINPUT || USE_BSD_LIBINPUT
+/*If only a single device of the same type is connected, you can also auto detect it, e.g.:
+ *#define LIBINPUT_NAME   libinput_find_dev(LIBINPUT_CAPABILITY_TOUCH, false)*/
 #  define LIBINPUT_NAME   "/dev/input/event0"        /*You can use the "evtest" Linux tool to get the list of devices and test them*/
+
 #endif  /*USE_LIBINPUT || USE_BSD_LIBINPUT*/
 
 /*-------------------------------------------------


### PR DESCRIPTION
This adds new convenience functions to the libinput driver for automatically detecting input devices of a certain type (such as keyboards or touchscreens).

My pointer magic is weak so I hope I did everything correctly here. Looking forward to candid feedback. :slightly_smiling_face: 

The logic could also be generalized to work with the evdev driver, too. That would just require replacing the libinput calls with `ioctl`s to the kernel. Since I'm not currently using the evdev driver, I didn't take the time to do that but it should be relatively straightforward for somebody else to do if they ever need it.

Closes: #155