### PR TITLE
fix(evdev) document parameter evdev_read returns void

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -113,7 +113,6 @@ bool evdev_set_file(char* dev_name)
 /**
  * Get the current position and state of the evdev
  * @param data store the evdev data here
- * @return false: because the points are not buffered, so no more data to be read
  */
 void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 {

--- a/indev/evdev.h
+++ b/indev/evdev.h
@@ -55,7 +55,6 @@ bool evdev_set_file(char* dev_name);
 /**
  * Get the current position and state of the evdev
  * @param data store the evdev data here
- * @return false: because the points are not buffered, so no more data to be read
  */
 void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 


### PR DESCRIPTION
evdev_read was changed to return void, but the parameter descriptions were not updated accordingly.