### PR TITLE
Add support for devices with KEY_POWER

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -208,6 +208,9 @@ void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
                     case KEY_TAB:
                         data->key = LV_KEY_NEXT;
                         break;
+                    case KEY_POWER:
+                        data->key = LV_KEY_POWER;
+                        break;
                     default:
                         data->key = 0;
                         break;

--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -279,6 +279,9 @@ static bool rescan_devices(void) {
     if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_TOUCH)) {
       capabilities |= LIBINPUT_CAPABILITY_TOUCH;
     }
+    if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_KEYBOARD) && libinput_device_keyboard_has_key(device, KEY_POWER)) {
+      capabilities |= LIBINPUT_CAPABILITY_POWER;
+    }
 
     libinput_path_remove_device(device);
 
@@ -420,6 +423,9 @@ static void read_keypad(struct libinput_event *event) {
           break;
         case KEY_TAB:
           libinput_key_val = LV_KEY_NEXT;
+          break;
+        case KEY_POWER:
+          libinput_key_val = LV_KEY_POWER;
           break;
         default:
           libinput_key_val = 0;

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -40,7 +40,8 @@ typedef enum {
   LIBINPUT_CAPABILITY_NONE     = 0,
   LIBINPUT_CAPABILITY_KEYBOARD = 1U << 0,
   LIBINPUT_CAPABILITY_POINTER  = 1U << 1,
-  LIBINPUT_CAPABILITY_TOUCH    = 1U << 2
+  LIBINPUT_CAPABILITY_TOUCH    = 1U << 2,
+  LIBINPUT_CAPABILITY_POWER    = 1U << 3
 } libinput_capability;
 
 /**********************

--- a/indev/xkb.c
+++ b/indev/xkb.c
@@ -160,6 +160,10 @@ uint32_t xkb_process_key(uint32_t scancode, bool down) {
     case XKB_KEY_ISO_Left_Tab: /* Sent on SHIFT + TAB */
       result = LV_KEY_PREV;
       break;
+    case XKB_KEY_XF86PowerDown:
+    case XKB_KEY_XF86PowerOff:
+      result = LV_KEY_POWER;
+      break;
     default:
       break;
   }


### PR DESCRIPTION
This makes it possible to automatically locate power buttons (which have `KEY_POWER)` via libinput. Additionally, a new `LV_KEY_POWER` key is introduced that is dispatched whenever KEY_POWER is pressed.

In order to handle `LV_KEY_POWER,` the client needs to register an indev  with type `LV_INDEV_TYPE_KEYPAD` and set the `feedback_cb` callback. Additionally, the indev needs to be assigned a group with at least one element.

**Note:** This is a draft and I'd like to get feedback on it. The fact that a group has to be assigned feels a little odd but that was the only way to make `feedback_cb` be called. After having tried it out, I'm not sure if this is a good way to implement support for `KEY_POWER`. Maybe it'd be better if the client would supply a custom `read_cb` and handle the `KEY_...` events manually because in the case of `KEY_POWER`, we don't really need any of the group logic?

Fixes: #161