### PR TITLE
Make it possible to set the variable offset for fbdev

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -254,6 +254,11 @@ void fbdev_get_sizes(uint32_t *width, uint32_t *height) {
         *height = vinfo.yres;
 }
 
+void fbdev_set_offset(uint32_t xoffset, uint32_t yoffset) {
+    vinfo.xoffset = xoffset;
+    vinfo.yoffset = yoffset;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/display/fbdev.h
+++ b/display/fbdev.h
@@ -44,6 +44,12 @@ void fbdev_init(void);
 void fbdev_exit(void);
 void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
 void fbdev_get_sizes(uint32_t *width, uint32_t *height);
+/**
+ * Set the X and Y offset in the variable framebuffer info.
+ * @param xoffset horizontal offset
+ * @param yoffset vertical offset
+ */
+void fbdev_set_offset(uint32_t xoffset, uint32_t yoffset);
 
 
 /**********************


### PR DESCRIPTION
This adds a new function for setting the x and y offset for the framebuffer display driver. This is useful when the driver should only
occupy part of the screen, for instance for an on-screen keyboard, and leave the remainder of the screen untouched.