### PR TITLE
Make it possible to use multiple devices with the libinput and XKB drivers

### DIFF
--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -29,6 +29,12 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#include <poll.h>
+
+#if USE_XKB
+#include "xkb.h"
+#endif /* USE_XKB */
+
 /*********************
  *      DEFINES
  *********************/
@@ -42,6 +48,22 @@ typedef enum {
   LIBINPUT_CAPABILITY_POINTER  = 1U << 1,
   LIBINPUT_CAPABILITY_TOUCH    = 1U << 2
 } libinput_capability;
+
+typedef struct {
+  int fd;
+  struct pollfd fds[1];
+
+  int button;
+  int key_val;
+  lv_point_t most_recent_touch_point;
+
+  struct libinput *libinput_context;
+  struct libinput_device *libinput_device;
+
+#if USE_XKB
+  xkb_drv_state_t xkb_state;
+#endif /* USE_XKB */
+} libinput_drv_state_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -66,23 +88,49 @@ char *libinput_find_dev(libinput_capability capabilities, bool force_rescan);
  */
 size_t libinput_find_devs(libinput_capability capabilities, char **found, size_t count, bool force_rescan);
 /**
- * Initialize the libinput
+ * Prepare for reading input via libinput using the default driver state. Use this function if you only want
+ * to connect a single device.
  */
 void libinput_init(void);
 /**
- * reconfigure the device file for libinput
- * @param dev_name set the libinput device filename
+ * Prepare for reading input via libinput using a specific driver state. Use this function if you want to
+ * connect multiple devices.
+ * @param state driver state to initialize
+ * @param path input device node path (e.g. /dev/input/event0)
+ */
+void libinput_init_state(libinput_drv_state_t *state, char* path);
+/**
+ * Reconfigure the device file for libinput using the default driver state. Use this function if you only want
+ * to connect a single device.
+ * @param dev_name input device node path (e.g. /dev/input/event0)
  * @return true: the device file set complete
  *         false: the device file doesn't exist current system
  */
 bool libinput_set_file(char* dev_name);
 /**
- * Get the current position and state of the libinput
+ * Reconfigure the device file for libinput using a specific driver state. Use this function if you want to
+ * connect multiple devices.
+ * @param state the driver state to configure
+ * @param dev_name input device node path (e.g. /dev/input/event0)
+ * @return true: the device file set complete
+ *         false: the device file doesn't exist current system
+ */
+bool libinput_set_file_state(libinput_drv_state_t *state, char* dev_name);
+/**
+ * Read available input events via libinput using the default driver state. Use this function if you only want
+ * to connect a single device.
  * @param indev_drv driver object itself
  * @param data store the libinput data here
  */
 void libinput_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
-
+/**
+ * Read available input events via libinput using a specific driver state. Use this function if you want to
+ * connect multiple devices.
+ * @param state the driver state to use
+ * @param indev_drv driver object itself
+ * @param data store the libinput data here
+ */
+void libinput_read_state(libinput_drv_state_t * state, lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
 
 /**********************
  *      MACROS

--- a/indev/xkb.h
+++ b/indev/xkb.h
@@ -38,29 +38,60 @@ extern "C" {
  **********************/
 struct xkb_rule_names;
 
+typedef struct {
+  struct xkb_keymap *keymap;
+  struct xkb_state *state;
+} xkb_drv_state_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
 /**
- * Initialise the XKB system
+ * Initialise the XKB system using the default driver state. Use this function if you only want
+ * to connect a single device.
  * @return true if the initialisation was successful
  */
 bool xkb_init(void);
 /**
- * Set a new keymap to be used for processing future key events
+ * Initialise the XKB system using a specific driver state. Use this function if you want to
+ * connect multiple devices.
+ * @param state XKB driver state to use
+ * @return true if the initialisation was successful
+ */
+bool xkb_init_state(xkb_drv_state_t *state);
+/**
+ * Set a new keymap to be used for processing future key events using the default driver state. Use
+ * this function if you only want to connect a single device.
  * @param names XKB rule names structure (use NULL components for default values)
  * @return true if creating the keymap and associated state succeeded
  */
 bool xkb_set_keymap(struct xkb_rule_names names);
 /**
- * Process an evdev scancode
+ * Set a new keymap to be used for processing future key events using a specific driver state. Use
+ * this function if you want to connect multiple devices.
+ * @param state XKB driver state to use
+ * @param names XKB rule names structure (use NULL components for default values)
+ * @return true if creating the keymap and associated state succeeded
+ */
+bool xkb_set_keymap_state(xkb_drv_state_t *state, struct xkb_rule_names names);
+/**
+ * Process an evdev scancode using the default driver state. Use this function if you only want to
+ * connect a single device.
  * @param scancode evdev scancode to process
  * @param down true if the key was pressed, false if it was releases
- * @param state associated XKB state
  * @return the (first) UTF-8 character produced by the event or 0 if no output was produced
  */
 uint32_t xkb_process_key(uint32_t scancode, bool down);
+/**
+ * Process an evdev scancode using a specific driver state. Use this function if you want to connect
+ * multiple devices.
+ * @param state XKB driver state to use
+ * @param scancode evdev scancode to process
+ * @param down true if the key was pressed, false if it was releases
+ * @return the (first) UTF-8 character produced by the event or 0 if no output was produced
+ */
+uint32_t xkb_process_key_state(xkb_drv_state_t *state, uint32_t scancode, bool down);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
This change bundles all of the previously file-global device-specific state in libinput.c and xkb.c into new driver state structs with a
default value. All of the existing public functions are retained and operate on the default struct values. To allow the use of multiple
devices, a second set of public functions is introduced that also take the specific driver state as an argument. It is left up to the caller where to store the driver state and how to retrieve it when reading input events.

The diff makes this look like a huge change but almost all of it just moves existing code around or renames variables.

Here is an example of how to use the new functions to connect multiple keyboards:

```
void libinput_read_cb(lv_indev_drv_t * indev_drv, lv_indev_data_t * data) {
    libinput_read_state(indev_drv->user_data, indev_drv, data); // <== Retrieve driver state from user data
}

int main(void)
{
    ...

    // Connect keyboards
    #define MAX_KEYBOARDS 4
    char *keyboard_devices[MAX_KEYBOARDS] = { NULL, NULL, NULL, NULL  };
    lv_indev_t *keyboard_indevs[MAX_KEYBOARDS] = { NULL, NULL, NULL, NULL };

    lv_indev_drv_t keyboard_indev_drvs[MAX_KEYBOARDS];
    memset(keyboard_indev_drvs, 0, MAX_KEYBOARDS * sizeof(lv_indev_drv_t));

    libinput_drv_state keyboard_drv_states[MAX_KEYBOARDS];
    memset(keyboard_drv_states, 0, MAX_KEYBOARDS * sizeof(libinput_drv_state));

    size_t num_keyboards = libinput_find_devs(LIBINPUT_CAPABILITY_KEYBOARD, keyboard_devices, MAX_KEYBOARDS, false);

    for (int i = 0; i < num_keyboards; ++i) {
        printf("found keyboard device %s\n", keyboard_devices[i]);
        libinput_init_state(&keyboard_drv_states[i], keyboard_devices[i]);
        lv_indev_drv_init(&keyboard_indev_drvs[i]);
        keyboard_indev_drvs[i].type = LV_INDEV_TYPE_KEYPAD;
        keyboard_indev_drvs[i].read_cb = libinput_read_cb; // <== Use custom read callback
        keyboard_indev_drvs[i].user_data = &keyboard_drv_states[i]; // <== Store driver state in user data
        keyboard_indevs[i] = lv_indev_drv_register(&keyboard_indev_drvs[i]);
    }
    
    ...
}
```

I'm hoping that this is a good compromise. The existing API interface is retained and merely extended with a second set of functions that perform the same operations but on a specific driver state. No assumptions are being made about where the driver state is stored and the overhead on the calling site to store and retrieve the state is minimal.

Closes: #151