### PR TITLE
fix(sdl) update monitor texture pointer during resize

### DIFF
--- a/sdl/sdl_gpu.c
+++ b/sdl/sdl_gpu.c
@@ -214,6 +214,7 @@ void sdl_display_resize(lv_disp_t *disp, int width, int height)
     }
     SDL_Texture *texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width,
                                              height);
+    monitor.texture = texture;
     lv_disp_draw_buf_init(driver->draw_buf, texture, NULL, width * height);
     driver->hor_res = (lv_coord_t) width;
     driver->ver_res = (lv_coord_t) height;

--- a/sdl/sdl_gpu.h
+++ b/sdl/sdl_gpu.h
@@ -77,6 +77,14 @@ void sdl_display_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_colo
 void sdl_display_flush2(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p);
 
 /**
+ * Resize SDL display
+ * @param disp pointer to lvgl display object
+ * @param width new display width in pixels
+ * @param height new display height in pixels
+ */
+void sdl_display_resize(lv_disp_t *disp, int width, int height);
+
+/**
  * Get the current position and state of the mouse
  * @param indev_drv pointer to the related input device driver
  * @param data store the mouse data here


### PR DESCRIPTION
Texture pointer in monitor struct should be updated during SDL window resize, otherwise the old texture pointer will still be in use and result in invalid memory accesses.