### PR TITLE
Enhanced Wayland support

### DIFF
--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -177,12 +177,6 @@
 #  define USE_WAYLAND       0
 #endif
 
-#if USE_WAYLAND
-#  define WAYLAND_HOR_RES      480
-#  define WAYLAND_VER_RES      320
-#  define WAYLAND_SURF_TITLE   "LVGL"
-#endif
-
 /*----------------
  *    SSD1963
  *--------------*/

--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -177,6 +177,21 @@
 #  define USE_WAYLAND       0
 #endif
 
+#if USE_WAYLAND
+/* Support for client-side decorations */
+#  ifndef LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+#    define LV_WAYLAND_CLIENT_SIDE_DECORATIONS 1
+#  endif
+/* Support for (deprecated) wl-shell protocol */
+#  ifndef LV_WAYLAND_WL_SHELL
+#    define LV_WAYLAND_WL_SHELL 1
+#  endif
+/* Support for xdg-shell protocol */
+#  ifndef LV_WAYLAND_XDG_SHELL
+#    define LV_WAYLAND_XDG_SHELL 0
+#  endif
+#endif
+
 /*----------------
  *    SSD1963
  *--------------*/

--- a/wayland/.gitignore
+++ b/wayland/.gitignore
@@ -1,0 +1,5 @@
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+/protocols

--- a/wayland/CMakeLists.txt
+++ b/wayland/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(lv_wayland)
+
+find_package(PkgConfig)
+pkg_check_modules(wayland-client REQUIRED wayland-client)
+pkg_check_modules(wayland-cursor REQUIRED wayland-cursor)
+pkg_check_modules(xkbcommon REQUIRED xkbcommon)
+
+# Wayland protocols
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.15)
+pkg_get_variable(WAYLAND_PROTOCOLS_BASE wayland-protocols pkgdatadir)
+
+macro(wayland_generate protocol_xml_file output_dir target)
+    get_filename_component(output_file_base ${protocol_xml_file} NAME_WE)
+    set(output_file_noext "${output_dir}/wayland-${output_file_base}-client-protocol")
+    add_custom_command(OUTPUT "${output_file_noext}.h"
+        COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" client-header "${protocol_xml_file}" "${output_file_noext}.h"
+        DEPENDS "${protocol_xml_file}"
+        VERBATIM)
+
+    add_custom_command(OUTPUT "${output_file_noext}.c"
+        COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" private-code "${protocol_xml_file}" "${output_file_noext}.c"
+        DEPENDS "${protocol_xml_file}"
+        VERBATIM)
+
+    if(NOT EXISTS ${protocol_xml_file})
+        message("Protocol XML file not found: " ${protocol_xml_file})
+    else()
+        set_property(TARGET ${target} APPEND PROPERTY SOURCES  "${output_file_noext}.h" "${output_file_noext}.c")
+    endif()
+endmacro()
+
+set(WAYLAND_PROTOCOLS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/protocols")
+file(MAKE_DIRECTORY ${WAYLAND_PROTOCOLS_DIR})
+
+add_custom_target(generate_protocols ALL)
+
+wayland_generate("${WAYLAND_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml" ${WAYLAND_PROTOCOLS_DIR} generate_protocols)

--- a/wayland/README.md
+++ b/wayland/README.md
@@ -33,10 +33,6 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   - Add ` ${wayland-libs}` and ` ${xkbcommon-libs}`  to the end (add a space between the last command and this)
 
 
-- "Cross GCC Linker > Libraries"
-  - Add `pthread`
-
-
 - In "C/C++ Build > Build variables"
   - Configuration: [All Configuration]
 
@@ -62,8 +58,9 @@ In "Project properties > C/C++ Build > Settings" set the followings:
 3. `LV_COLOR_DEPTH` should be set either to `32` or `16` in `lv_conf.h`;
    support for `8` and `1` depends on target platform.
 4. After `lv_init()` call `lv_wayland_init()`
-5. Before `lv_deinit()` call `lv_wayland_deinit()`
-6. Add a display:
+5. Periodically call `lv_wayland_tick()` - ideally after `lv_timer_handler()`
+6. After `lv_deinit()` call `lv_wayland_deinit()`
+7. Add a display:
 ```c
   static lv_disp_draw_buf_t draw_buf;
   static lv_color_t buf1[WAYLAND_HOR_RES * WAYLAND_VER_RES];
@@ -78,7 +75,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   disp_drv.flush_cb = lv_wayland_flush;
   lv_disp_t * disp = lv_disp_drv_register(&disp_drv);
 ```
-7. Add keyboard:
+8. Add keyboard:
 ```c
   lv_indev_drv_t indev_drv_kb;
   lv_indev_drv_init(&indev_drv_kb);
@@ -86,7 +83,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   indev_drv_kb.read_cb = lv_wayland_keyboard_read;
   lv_indev_drv_register(&indev_drv_kb);
 ```
-8. Add touchscreen:
+9. Add touchscreen:
 ```c
   lv_indev_drv_t indev_drv_touch;
   lv_indev_drv_init(&indev_drv_touch);
@@ -94,7 +91,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   indev_drv_touch.read_cb = lv_wayland_touch_read;
   lv_indev_drv_register(&indev_drv_touch);
 ```
-9. Add mouse:
+10. Add mouse:
 ```c
   lv_indev_drv_t indev_drv_mouse;
   lv_indev_drv_init(&indev_drv_mouse);
@@ -102,7 +99,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   indev_drv_mouse.read_cb = lv_wayland_pointer_read;
   lv_indev_drv_register(&indev_drv_mouse);
 ```
-10. Add mouse wheel as encoder:
+11. Add mouse wheel as encoder:
 ```c
   lv_indev_drv_t indev_drv_mousewheel;
   lv_indev_drv_init(&indev_drv_mousewheel);

--- a/wayland/README.md
+++ b/wayland/README.md
@@ -61,8 +61,8 @@ In "Project properties > C/C++ Build > Settings" set the followings:
 2. Enable the Wayland driver in `lv_drv_conf.h` with `USE_WAYLAND 1`
 3. `LV_COLOR_DEPTH` should be set either to `32` or `16` in `lv_conf.h`;
    support for `8` and `1` depends on target platform.
-4. After `lv_init()` call `wayland_init()`
-5. Before `lv_deinit()` call `wayland_deinit()`
+4. After `lv_init()` call `lv_wayland_init()`
+5. Before `lv_deinit()` call `lv_wayland_deinit()`
 6. Add a display:
 ```c
   static lv_disp_draw_buf_t draw_buf;
@@ -75,7 +75,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   disp_drv.draw_buf = &draw_buf;
   disp_drv.hor_res = WAYLAND_HOR_RES;
   disp_drv.ver_res = WAYLAND_VER_RES;
-  disp_drv.flush_cb = wayland_flush;
+  disp_drv.flush_cb = lv_wayland_flush;
   lv_disp_t * disp = lv_disp_drv_register(&disp_drv);
 ```
 7. Add keyboard:
@@ -83,7 +83,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   lv_indev_drv_t indev_drv_kb;
   lv_indev_drv_init(&indev_drv_kb);
   indev_drv_kb.type = LV_INDEV_TYPE_KEYPAD;
-  indev_drv_kb.read_cb = wayland_keyboard_read;
+  indev_drv_kb.read_cb = lv_wayland_keyboard_read;
   lv_indev_drv_register(&indev_drv_kb);
 ```
 8. Add touchscreen:
@@ -91,7 +91,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   lv_indev_drv_t indev_drv_touch;
   lv_indev_drv_init(&indev_drv_touch);
   indev_drv_touch.type = LV_INDEV_TYPE_POINTER;
-  indev_drv_touch.read_cb = wayland_touch_read;
+  indev_drv_touch.read_cb = lv_wayland_touch_read;
   lv_indev_drv_register(&indev_drv_touch);
 ```
 9. Add mouse:
@@ -99,7 +99,7 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   lv_indev_drv_t indev_drv_mouse;
   lv_indev_drv_init(&indev_drv_mouse);
   indev_drv_mouse.type = LV_INDEV_TYPE_POINTER;
-  indev_drv_mouse.read_cb = wayland_pointer_read;
+  indev_drv_mouse.read_cb = lv_wayland_pointer_read;
   lv_indev_drv_register(&indev_drv_mouse);
 ```
 10. Add mouse wheel as encoder:
@@ -107,6 +107,6 @@ In "Project properties > C/C++ Build > Settings" set the followings:
   lv_indev_drv_t indev_drv_mousewheel;
   lv_indev_drv_init(&indev_drv_mousewheel);
   indev_drv_mousewheel.type = LV_INDEV_TYPE_ENCODER;
-  indev_drv_mousewheel.read_cb = wayland_pointeraxis_read;
+  indev_drv_mousewheel.read_cb = lv_wayland_pointeraxis_read;
   lv_indev_drv_register(&indev_drv_mousewheel);
 ```

--- a/wayland/README.md
+++ b/wayland/README.md
@@ -1,9 +1,18 @@
 # Wayland display and input driver
 
-Wayland display and input driver, with support for keyboard, mouse and touchscreen.
+Wayland display and input driver, with support for keyboard, pointer (i.e. mouse) and touchscreen.
 Keyboard support is based on libxkbcommon.
 
-> NOTE: current implementation only supports `wl_shell` shell with no decorations.
+Following shell are supported:
+
+* wl_shell (deprecated)
+* xdg_shell
+
+> xdg_shell requires an extra build step; see section _Generate protocols_ below.
+
+
+Basic client-side window decorations (simple title bar, minimize and close buttons)
+are supported, while integration with desktop environments is not.
 
 
 ## Install headers and libraries
@@ -11,13 +20,26 @@ Keyboard support is based on libxkbcommon.
 ### Ubuntu
 
 ```
-sudo apt-get install libwayland-dev libxkbcommon-dev
+sudo apt-get install libwayland-dev libxkbcommon-dev libwayland-bin wayland-protocols
 ```
 
 ### Fedora
 
 ```
-sudo dnf install wayland-devel libxkbcommon-devel
+sudo dnf install wayland-devel libxkbcommon-devel wayland-utils wayland-protocols-devel
+```
+
+
+## Generate protocols
+
+Support for non-basic shells (i.e. other than _wl_shell_) requires additional
+source files to be generated before the first build of the project. To do so,
+navigate to the _wayland_ folder (the one which includes this file) and issue
+the following commands:
+
+```
+cmake .
+make
 ```
 
 
@@ -54,56 +76,35 @@ In "Project properties > C/C++ Build > Settings" set the followings:
 ## Init Wayland in LVGL
 
 1. In `main.c` `#incude "lv_drivers/wayland/wayland.h"`
-2. Enable the Wayland driver in `lv_drv_conf.h` with `USE_WAYLAND 1`
+2. Enable the Wayland driver in `lv_drv_conf.h` with `USE_WAYLAND 1` and
+   configure its features below, enabling at least support for one shell.
 3. `LV_COLOR_DEPTH` should be set either to `32` or `16` in `lv_conf.h`;
    support for `8` and `1` depends on target platform.
-4. After `lv_init()` call `lv_wayland_init()`
-5. Periodically call `lv_wayland_tick()` - ideally after `lv_timer_handler()`
-6. After `lv_deinit()` call `lv_wayland_deinit()`
-7. Add a display:
+4. After `lv_init()` call `lv_wayland_init()`.
+5. Add a display (or more than one) using `lv_wayland_create_window()`,
+   possibly with a close callback to track the status of each display:
 ```c
-  static lv_disp_draw_buf_t draw_buf;
-  static lv_color_t buf1[WAYLAND_HOR_RES * WAYLAND_VER_RES];
-  lv_disp_draw_buf_init(&draw_buf, buf1, NULL, WAYLAND_HOR_RES * WAYLAND_VER_RES);
+  #define H_RES (800)
+  #define V_RES (480)
 
   /* Create a display */
-  static lv_disp_drv_t disp_drv;
-  lv_disp_drv_init(&disp_drv);
-  disp_drv.draw_buf = &draw_buf;
-  disp_drv.hor_res = WAYLAND_HOR_RES;
-  disp_drv.ver_res = WAYLAND_VER_RES;
-  disp_drv.flush_cb = lv_wayland_flush;
-  lv_disp_t * disp = lv_disp_drv_register(&disp_drv);
+  lv_disp_t * disp = lv_wayland_create_window(H_RES, V_RES, "Window Title", close_cb);
 ```
-8. Add keyboard:
-```c
-  lv_indev_drv_t indev_drv_kb;
-  lv_indev_drv_init(&indev_drv_kb);
-  indev_drv_kb.type = LV_INDEV_TYPE_KEYPAD;
-  indev_drv_kb.read_cb = lv_wayland_keyboard_read;
-  lv_indev_drv_register(&indev_drv_kb);
-```
-9. Add touchscreen:
-```c
-  lv_indev_drv_t indev_drv_touch;
-  lv_indev_drv_init(&indev_drv_touch);
-  indev_drv_touch.type = LV_INDEV_TYPE_POINTER;
-  indev_drv_touch.read_cb = lv_wayland_touch_read;
-  lv_indev_drv_register(&indev_drv_touch);
-```
-10. Add mouse:
-```c
-  lv_indev_drv_t indev_drv_mouse;
-  lv_indev_drv_init(&indev_drv_mouse);
-  indev_drv_mouse.type = LV_INDEV_TYPE_POINTER;
-  indev_drv_mouse.read_cb = lv_wayland_pointer_read;
-  lv_indev_drv_register(&indev_drv_mouse);
-```
-11. Add mouse wheel as encoder:
-```c
-  lv_indev_drv_t indev_drv_mousewheel;
-  lv_indev_drv_init(&indev_drv_mousewheel);
-  indev_drv_mousewheel.type = LV_INDEV_TYPE_ENCODER;
-  indev_drv_mousewheel.read_cb = lv_wayland_pointeraxis_read;
-  lv_indev_drv_register(&indev_drv_mousewheel);
-```
+  As part of the above call, the Wayland driver will register four input devices
+  for each display:
+  - a KEYPAD connected to Wayland keyboard events
+  - a POINTER connected to Wayland touch events
+  - a POINTER connected to Wayland pointer events
+  - a ENCODER connected to Wayland pointer axis events
+  Handles for input devices of each display can be get using respectively
+  `lv_wayland_get_indev_keyboard()`, `lv_wayland_get_indev_touchscreen()`,
+  `lv_wayland_get_indev_pointer()` and `lv_wayland_get_indev_pointeraxis()`, using
+  `disp` as argument.
+5. After `lv_deinit()` (if used), or in any case during de-initialization, call
+  `lv_wayland_deinit()`.
+
+### Disable window client-side decoration at runtime
+
+Even when client-side decorations are enabled at compile time, they can be
+disabled at runtime setting the `LV_WAYLAND_DISABLE_WINDOWDECORATION`
+environment variable to `1`.

--- a/wayland/wayland.c
+++ b/wayland/wayland.c
@@ -22,59 +22,156 @@
 #include <sys/mman.h>
 
 #include <linux/input.h>
+#include <linux/input-event-codes.h>
 
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 #include <xkbcommon/xkbcommon.h>
+
+#if !(LV_WAYLAND_XDG_SHELL || LV_WAYLAND_WL_SHELL)
+#error "Please select at least one shell integration for Wayland driver"
+#endif
+
+#if LV_WAYLAND_XDG_SHELL
+#include "protocols/wayland-xdg-shell-client-protocol.h"
+#endif
 
 /*********************
  *      DEFINES
  *********************/
 
+#define BYTES_PER_PIXEL ((LV_COLOR_DEPTH + 7) / 8)
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+#define TITLE_BAR_HEIGHT 24
+#define BORDER_SIZE 2
+#define BUTTON_MARGIN LV_MAX((TITLE_BAR_HEIGHT / 6), BORDER_SIZE)
+#define BUTTON_PADDING LV_MAX((TITLE_BAR_HEIGHT / 8), BORDER_SIZE)
+#define BUTTON_SIZE (TITLE_BAR_HEIGHT - (2 * BUTTON_MARGIN))
+#endif
+
+#ifndef LV_WAYLAND_CYCLE_PERIOD
+#define LV_WAYLAND_CYCLE_PERIOD LV_MIN(LV_DISP_DEF_REFR_PERIOD,1)
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
 
-struct input {
-    struct {
+enum object_type {
+    OBJECT_TITLEBAR,
+    OBJECT_BUTTON_CLOSE,
+#if LV_WAYLAND_XDG_SHELL
+    OBJECT_BUTTON_MAXIMIZE,
+    OBJECT_BUTTON_MINIMIZE,
+#endif
+    OBJECT_BORDER_TOP,
+    OBJECT_BORDER_BOTTOM,
+    OBJECT_BORDER_LEFT,
+    OBJECT_BORDER_RIGHT,
+    FIRST_DECORATION = OBJECT_TITLEBAR,
+    LAST_DECORATION = OBJECT_BORDER_RIGHT,
+    OBJECT_WINDOW,
+};
+
+#define NUM_DECORATIONS (LAST_DECORATION-FIRST_DECORATION+1)
+
+struct window;
+struct input
+{
+    struct
+    {
         lv_coord_t x;
         lv_coord_t y;
         lv_indev_state_t left_button;
         lv_indev_state_t right_button;
         lv_indev_state_t wheel_button;
         int16_t wheel_diff;
-    } mouse;
+    } pointer;
 
-    struct {
+    struct
+    {
         lv_key_t key;
         lv_indev_state_t state;
     } keyboard;
 
-    struct {
+    struct
+    {
         lv_coord_t x;
         lv_coord_t y;
         lv_indev_state_t state;
     } touch;
 };
 
-struct seat {
+struct seat
+{
     struct wl_touch *wl_touch;
     struct wl_pointer *wl_pointer;
     struct wl_keyboard *wl_keyboard;
 
-    struct {
+    struct
+    {
         struct xkb_keymap *keymap;
         struct xkb_state *state;
     } xkb;
 };
 
-struct application {
+struct buffer_hdl
+{
+    void *base;
+    int size;
+    struct wl_buffer *wl_buffer;
+};
+
+struct buffer_allocator
+{
+    int shm_mem_fd;
+    int shm_mem_size;
+    int shm_file_free_size;
+    struct wl_shm_pool *shm_pool;
+};
+
+struct graphic_object
+{
+    struct window *window;
+
+    struct wl_surface *surface;
+    struct wl_subsurface *subsurface;
+
+    enum object_type type;
+    int width;
+    int height;
+
+    struct buffer_hdl buffer;
+
+    struct input input;
+};
+
+struct application
+{
     struct wl_display *display;
     struct wl_registry *registry;
     struct wl_compositor *compositor;
+    struct wl_subcompositor *subcompositor;
     struct wl_shm *shm;
-    struct wl_shell *shell;
     struct wl_seat *wl_seat;
+
+    struct wl_cursor_theme *cursor_theme;
+    struct wl_surface *cursor_surface;
+
+#if LV_WAYLAND_WL_SHELL
+    struct wl_shell *wl_shell;
+#endif
+
+#if LV_WAYLAND_XDG_SHELL
+    struct xdg_wm_base *xdg_wm;
+#endif
+
     const char *xdg_runtime_dir;
+
+#ifdef LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    bool opt_disable_decorations;
+#endif
 
     uint32_t format;
 
@@ -82,492 +179,100 @@ struct application {
 
     struct seat seat;
 
-    struct window *touch_window;
-    struct window *pointer_window;
-    struct window *keyboard_window;
+    struct graphic_object *touch_obj;
+    struct graphic_object *pointer_obj;
+    struct graphic_object *keyboard_obj;
 
-    lv_ll_t  window_ll;
+    lv_ll_t window_ll;
+    lv_timer_t * cycle_timer;
 
-    bool shall_flush_display;
+    bool cursor_flush_pending;
 };
 
-struct window {
+struct window
+{
+    lv_disp_drv_t lv_disp_drv;
+    lv_disp_draw_buf_t lv_disp_draw_buf;
+    lv_disp_t *lv_disp;
+
+    lv_indev_drv_t lv_indev_drv_pointer;
+    lv_indev_t * lv_indev_pointer;
+
+    lv_indev_drv_t lv_indev_drv_pointeraxis;
+    lv_indev_t * lv_indev_pointeraxis;
+
+    lv_indev_drv_t lv_indev_drv_touch;
+    lv_indev_t * lv_indev_touch;
+
+    lv_indev_drv_t lv_indev_drv_keyboard;
+    lv_indev_t * lv_indev_keyboard;
+
+    lv_wayland_display_close_f_t close_cb;
+
     struct application *application;
 
-    struct wl_shm *shm;
-    struct wl_buffer *buffer;
-    struct wl_surface *surface;
+#if LV_WAYLAND_WL_SHELL
+    struct wl_shell_surface *wl_shell_surface;
+#endif
 
-    struct wl_shell_surface *shell_surface;
+#if LV_WAYLAND_XDG_SHELL
+    struct xdg_surface *xdg_surface;
+    struct xdg_toplevel *xdg_toplevel;
+#endif
+
+    struct buffer_allocator allocator;
+
+    struct graphic_object * body;
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    struct graphic_object * decoration[NUM_DECORATIONS];
+#endif
 
     int width;
     int height;
-    void *data;
 
-    struct input input;
+    bool flush_pending;
+    bool shall_close;
+    bool closed;
+    bool maximized;
 };
 
-/**********************
- *  STATIC PROTOTYPES
- **********************/
-static struct window * create_window(struct application *app, int width, int height);
-static void handle_global(void *data, struct wl_registry *registry, uint32_t name,
-                          const char *interface, uint32_t version);
-static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name);
+/*********************************
+ *   STATIC VARIABLES and FUNTIONS
+ *********************************/
 
-static void shm_format(void *data, struct wl_shm *wl_shm, uint32_t format);
-
-static void shell_handle_ping(void *data, struct wl_shell_surface *shell_surface, uint32_t serial);
-static void shell_handle_configure(void *data, struct wl_shell_surface *shell_surface,
-                                   uint32_t edges, int32_t width, int32_t height);
-static void shell_handle_popup_done(void *data, struct wl_shell_surface *shell_surface);
-static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat, enum wl_seat_capability caps);
-
-static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
-                                 uint32_t serial, struct wl_surface *surface,
-                                 wl_fixed_t sx, wl_fixed_t sy);
-static void pointer_handle_leave(void *data, struct wl_pointer *pointer,
-                                 uint32_t serial, struct wl_surface *surface);
-static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
-                                  uint32_t time, wl_fixed_t sx, wl_fixed_t sy);
-static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
-                                  uint32_t serial, uint32_t time, uint32_t button,
-                                  uint32_t state);
-static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
-                                uint32_t time, uint32_t axis, wl_fixed_t value);
-
-static void keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,
-                                   uint32_t format, int fd, uint32_t size);
-static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard,
-                                  uint32_t serial, struct wl_surface *surface,
-                                  struct wl_array *keys);
-static void keyboard_handle_leave(void *data, struct wl_keyboard *keyboard,
-                                  uint32_t serial, struct wl_surface *surface);
-static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard,
-                                uint32_t serial, uint32_t time, uint32_t key,
-                                uint32_t state);
-static void keyboard_handle_modifiers(void *data, struct wl_keyboard *keyboard,
-                                      uint32_t serial, uint32_t mods_depressed,
-                                      uint32_t mods_latched, uint32_t mods_locked,
-                                      uint32_t group);
-
-static void touch_handle_down(void *data, struct wl_touch *wl_touch,
-                              uint32_t serial, uint32_t time, struct wl_surface *surface,
-                              int32_t id, wl_fixed_t x_w, wl_fixed_t y_w);
-static void touch_handle_up(void *data, struct wl_touch *wl_touch,
-                            uint32_t serial, uint32_t time, int32_t id);
-static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
-                                uint32_t time, int32_t id, wl_fixed_t x_w, wl_fixed_t y_w);
-static void touch_handle_frame(void *data, struct wl_touch *wl_touch);
-static void touch_handle_cancel(void *data, struct wl_touch *wl_touch);
-
-static lv_key_t keycode_xkb_to_lv(uint32_t xkb_key);
-
-/**********************
- *  STATIC VARIABLES
- **********************/
-static const struct wl_registry_listener registry_listener = {
-    handle_global,
-    handle_global_remove
-};
-
-struct wl_shm_listener shm_listener = {
-    shm_format
-};
-
-static const struct wl_shell_surface_listener shell_surface_listener = {
-    shell_handle_ping,
-    shell_handle_configure,
-    shell_handle_popup_done
-};
-
-static const struct wl_seat_listener seat_listener = {
-    seat_handle_capabilities,
-};
-
-static const struct wl_pointer_listener pointer_listener = {
-    pointer_handle_enter,
-    pointer_handle_leave,
-    pointer_handle_motion,
-    pointer_handle_button,
-    pointer_handle_axis,
-};
-
-static const struct wl_keyboard_listener keyboard_listener = {
-    keyboard_handle_keymap,
-    keyboard_handle_enter,
-    keyboard_handle_leave,
-    keyboard_handle_key,
-    keyboard_handle_modifiers,
-};
-
-static const struct wl_touch_listener touch_listener = {
-    touch_handle_down,
-    touch_handle_up,
-    touch_handle_motion,
-    touch_handle_frame,
-    touch_handle_cancel,
-};
+static bool resize_window(struct window *window, int width, int height);
 
 static struct application application;
 
-/**********************
- *      MACROS
- **********************/
-
-/**********************
- *   GLOBAL FUNCTIONS
- **********************/
-/**
- * Initialize Wayland driver
- */
-void lv_wayland_init(void)
+static inline bool _is_digit(char ch)
 {
-    // Create XKB context
-    application.xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    LV_ASSERT_MSG(application.xkb_context, "failed to create XKB context");
-    if (application.xkb_context == NULL) {
-        return;
-    }
-
-    // Connect to Wayland display
-    application.display = wl_display_connect(NULL);
-    LV_ASSERT_MSG(application.display, "failed to connect to Wayland server");
-    if (application.display == NULL) {
-        return;
-    }
-
-    /* Add registry listener and wait for registry reception */
-    application.format = 0xFFFFFFFF;
-    application.registry = wl_display_get_registry(application.display);
-    wl_registry_add_listener(application.registry, &registry_listener, &application);
-    wl_display_dispatch(application.display);
-    wl_display_roundtrip(application.display);
-
-    LV_ASSERT_MSG((application.format != 0xFFFFFFFF), "WL_SHM_FORMAT not available");
-    if (application.format == 0xFFFFFFFF) {
-        return;
-    }
-
-    application.xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
-    LV_ASSERT_MSG(application.xdg_runtime_dir, "cannot get XDG_RUNTIME_DIR");
-
-    _lv_ll_init(&application.window_ll, sizeof(struct window));
+    return (ch >= '0') && (ch <= '9');
 }
 
-/**
- * De-initialize Wayland driver
- */
-void lv_wayland_deinit(void)
+static unsigned int _atoi(const char ** str)
 {
-    struct window *window;
-
-    _LV_LL_READ(&application.window_ll, window) {
-        wl_shell_surface_destroy(window->shell_surface);
-        wl_surface_destroy(window->surface);
-    }
-
-    if (application.shm) {
-        wl_shm_destroy(application.shm);
-    }
-
-    if (application.shell) {
-        wl_shell_destroy(application.shell);
-    }
-
-    if (application.wl_seat) {
-        wl_seat_destroy(application.wl_seat);
-    }
-
-    if (application.compositor) {
-        wl_compositor_destroy(application.compositor);
-    }
-
-    wl_registry_destroy(application.registry);
-    wl_display_flush(application.display);
-    wl_display_disconnect(application.display);
-
-    _lv_ll_clear(&application.window_ll);
-}
-
-/**
- * Flush a buffer to the marked area
- * @param drv pointer to driver where this function belongs
- * @param area an area where to copy `color_p`
- * @param color_p an array of pixel to copy to the `area` part of the screen
- */
-void lv_wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p)
-{
-    struct window *window = disp_drv->user_data;
-    lv_coord_t hres = (disp_drv->rotated == 0) ? (disp_drv->hor_res) : (disp_drv->ver_res);
-    lv_coord_t vres = (disp_drv->rotated == 0) ? (disp_drv->ver_res) : (disp_drv->hor_res);
-
-    /* If private data is not set, it means window has not been created yet */
-    if (!window) {
-        window = create_window(&application, hres, vres);
-        if (!window) {
-            LV_LOG_ERROR("failed to create wayland window\n");
-            return;
-        }
-        disp_drv->user_data = window;
-    }
-
-    /* Return if the area is out the screen */
-    if ((area->x2 < 0) || (area->y2 < 0) || (area->x1 > hres - 1) || (area->y1 > vres - 1)) {
-        lv_disp_flush_ready(disp_drv);
-        return;
-    }
-
-    int32_t x;
-    int32_t y;
-    for (y = area->y1; y <= area->y2 && y < disp_drv->ver_res; y++) {
-        for (x = area->x1; x <= area->x2 && x < disp_drv->hor_res; x++) {
-            int offset = (y * disp_drv->hor_res) + x;
-#if (LV_COLOR_DEPTH == 32)
-            uint32_t * const buf = (uint32_t *)window->data + offset;
-            *buf = color_p->full;
-#elif (LV_COLOR_DEPTH == 16)
-            uint16_t * const buf = (uint16_t *)window->data + offset;
-            *buf = color_p->full;
-#elif (LV_COLOR_DEPTH == 8)
-            uint8_t * const buf = (uint8_t *)window->data + offset;
-            *buf = color_p->full;
-#elif (LV_COLOR_DEPTH == 1)
-            uint8_t * const buf = (uint8_t *)window->data + offset;
-            *buf = ((0x07 * color_p->ch.red)   << 5) |
-                   ((0x07 * color_p->ch.green) << 2) |
-                   ((0x03 * color_p->ch.blue)  << 0);
-#endif
-            color_p++;
-        }
-    }
-
-    wl_surface_attach(window->surface, window->buffer, 0, 0);
-    wl_surface_damage(window->surface, area->x1, area->y1,
-                      (area->x2 - area->x1 + 1), (area->y2 - area->y1 + 1));
-    wl_surface_commit(window->surface);
-
-    window->application->shall_flush_display = true;
-
-    lv_disp_flush_ready(disp_drv);
-}
-
-/**
- * Dispath Wayland events and flush changes to server
- */
-void lv_wayland_cycle(void)
-{
-    while (wl_display_prepare_read(application.display) != 0)
+    unsigned int i = 0U;
+    while (_is_digit(**str))
     {
-        wl_display_dispatch_pending(application.display);
+        i = i * 10U + (unsigned int)(*((*str)++) - '0');
     }
-
-    if (application.shall_flush_display)
-    {
-        wl_display_flush(application.display);
-        application.shall_flush_display = false;
-    }
-
-    wl_display_read_events(application.display);
-    wl_display_dispatch_pending(application.display);
+    return i;
 }
-
-/**
- * Read pointer input
- * @param drv pointer to driver where this function belongs
- * @param data where to store input data
- */
-void lv_wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
-{
-    struct window *window = drv->disp->driver->user_data;
-    if (!window)
-        return;
-
-    data->point.x = window->input.mouse.x;
-    data->point.y = window->input.mouse.y;
-    data->state = window->input.mouse.left_button;
-}
-
-/**
- * Read axis input
- * @param drv pointer to driver where this function belongs
- * @param data where to store input data
- */
-void lv_wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
-{
-    struct window *window = drv->disp->driver->user_data;
-    if (!window)
-        return;
-
-    data->state = window->input.mouse.wheel_button;
-    data->enc_diff = window->input.mouse.wheel_diff;
-
-    window->input.mouse.wheel_diff = 0;
-}
-
-/**
- * Read keyboard input
- * @param drv pointer to driver where this function belongs
- * @param data where to store input data
- */
-void lv_wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
-{
-    struct window *window = drv->disp->driver->user_data;
-    if (!window)
-        return;
-
-    data->key = window->input.keyboard.key;
-    data->state = window->input.keyboard.state;
-}
-
-/**
- * Read touch input
- * @param drv pointer to driver where this function belongs
- * @param data where to store input data
- */
-void lv_wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
-{
-    struct window *window = drv->disp->driver->user_data;
-    if (!window)
-        return;
-
-    data->point.x = window->input.touch.x;
-    data->point.y = window->input.touch.y;
-    data->state = window->input.touch.state;
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-static struct window * create_window(struct application *app, int width, int height)
-{
-    static const char template[] = "/lvgl-wayland-XXXXXX";
-    struct window *window;
-    struct wl_shm_pool *shm_pool;
-    int stride;
-    int size;
-    char *name;
-    int ret;
-    int fd;
-
-    window = _lv_ll_ins_tail(&app->window_ll);
-    LV_ASSERT_MALLOC(window);
-    if (!window)
-        return NULL;
-
-    window->width = width;
-    window->height = height;
-    window->application = app;
-
-    stride = width * ((LV_COLOR_DEPTH + 7) / 8);
-    size = stride * height;
-
-    name = lv_mem_alloc(strlen(app->xdg_runtime_dir) + sizeof(template));
-    if (!name) {
-        LV_LOG_ERROR("cannot allocate memory for name: %s\n", strerror(errno));
-        goto err_free_window;
-    }
-
-    strcpy(name, app->xdg_runtime_dir);
-    strcat(name, template);
-
-    fd = mkstemp(name);
-
-    lv_mem_free(name);
-
-    if (fd < 0) {
-        LV_LOG_ERROR("cannot create tmpfile: %s\n", strerror(errno));
-        goto err_free_window;
-    }
-
-    do {
-        ret = ftruncate(fd, size);
-    } while ((ret < 0) && (errno == EINTR));
-    if (ret < 0) {
-        LV_LOG_ERROR("ftruncate failed: %s\n", strerror(errno));
-        goto err_close_fd;
-    }
-
-    window->data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    if (window->data == MAP_FAILED) {
-        LV_LOG_ERROR("mmap failed: %s\n", strerror(errno));
-        goto err_close_fd;
-    }
-
-    shm_pool = wl_shm_create_pool(app->shm, fd, size);
-    window->buffer = wl_shm_pool_create_buffer(shm_pool, 0, width, height,
-                                               stride, app->format);
-
-    close(fd);
-
-    // Create compositor surface
-    window->surface = wl_compositor_create_surface(app->compositor);
-    LV_ASSERT_MSG(window->surface, "cannot create surface");
-    if (!window->surface) {
-        goto err_close_fd;
-    }
-
-    wl_surface_set_user_data(window->surface, window);
-
-    // Create shell surface
-    window->shell_surface = wl_shell_get_shell_surface(app->shell, window->surface);
-    LV_ASSERT_MSG(window->shell_surface, "cannot create shell surface");
-    if (!window->surface) {
-        goto err_destroy_surface;
-    }
-
-
-    wl_shell_surface_add_listener(window->shell_surface, &shell_surface_listener, &window);
-    wl_shell_surface_set_toplevel(window->shell_surface);
-
-    return window;
-
-err_destroy_surface:
-    wl_surface_destroy(window->surface);
-
-err_close_fd:
-    close(fd);
-
-err_free_window:
-    _lv_ll_remove(&app->window_ll, window);
-    lv_mem_free(window);
-    return NULL;
-}
-
-static void handle_global(void *data, struct wl_registry *registry,
-                          uint32_t name, const char *interface, uint32_t version)
-{
-    struct application *app = data;
-
-    if (strcmp(interface, "wl_compositor") == 0) {
-        app->compositor = wl_registry_bind(registry, name, &wl_compositor_interface, 1);
-    } else if (strcmp(interface, "wl_shell") == 0) {
-        app->shell = wl_registry_bind(registry, name, &wl_shell_interface, 1);
-    } else if (strcmp(interface, "wl_shm") == 0) {
-        app->shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
-        wl_shm_add_listener(app->shm, &shm_listener, app);
-    } else if (strcmp(interface, "wl_seat") == 0) {
-        app->wl_seat = wl_registry_bind(app->registry, name, &wl_seat_interface, 1);
-        wl_seat_add_listener(app->wl_seat, &seat_listener, app);
-    }
-}
-
-static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name)
-{
-}
-
 
 static void shm_format(void *data, struct wl_shm *wl_shm, uint32_t format)
 {
     struct application *app = data;
 
-    switch (format) {
+    switch (format)
+    {
 #if (LV_COLOR_DEPTH == 32)
     case WL_SHM_FORMAT_ARGB8888:
         app->format = format;
         break;
     case WL_SHM_FORMAT_XRGB8888:
-        if (app->format != WL_SHM_FORMAT_ARGB8888) {
+        if (app->format != WL_SHM_FORMAT_ARGB8888)
+        {
             app->format = format;
         }
         break;
@@ -589,70 +294,136 @@ static void shm_format(void *data, struct wl_shm *wl_shm, uint32_t format)
     }
 }
 
-static void shell_handle_ping(void *data, struct wl_shell_surface *shell_surface, uint32_t serial)
-{
-    wl_shell_surface_pong(shell_surface, serial);
-}
-
-static void shell_handle_configure(void *data, struct wl_shell_surface *shell_surface,
-                                   uint32_t edges, int32_t width, int32_t height)
-{
-}
-
-static void shell_handle_popup_done(void *data, struct wl_shell_surface *shell_surface)
-{
-}
-
-static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat, enum wl_seat_capability caps)
-{
-    struct application *application = data;
-    struct seat *seat = &application->seat;
-
-    if ((caps & WL_SEAT_CAPABILITY_POINTER) && !seat->wl_pointer) {
-        seat->wl_pointer = wl_seat_get_pointer(wl_seat);
-        wl_pointer_add_listener(seat->wl_pointer, &pointer_listener, application);
-    } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && seat->wl_pointer) {
-        wl_pointer_destroy(seat->wl_pointer);
-        seat->wl_pointer = NULL;
-    }
-
-    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !seat->wl_keyboard) {
-        seat->wl_keyboard = wl_seat_get_keyboard(wl_seat);
-        wl_keyboard_add_listener(seat->wl_keyboard, &keyboard_listener, application);
-    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && seat->wl_keyboard) {
-        wl_keyboard_destroy(seat->wl_keyboard);
-        seat->wl_keyboard = NULL;
-    }
-
-    if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !seat->wl_touch) {
-        seat->wl_touch = wl_seat_get_touch(wl_seat);
-        wl_touch_add_listener(seat->wl_touch, &touch_listener, application);
-    } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && seat->wl_touch) {
-        wl_touch_destroy(seat->wl_touch);
-        seat->wl_touch = NULL;
-    }
-}
+static const struct wl_shm_listener shm_listener = {
+    shm_format
+};
 
 static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
                                  uint32_t serial, struct wl_surface *surface,
                                  wl_fixed_t sx, wl_fixed_t sy)
 {
     struct application *app = data;
-    struct window *window = wl_surface_get_user_data(surface);
-    app->pointer_window = window;
+    const char * cursor = "left_ptr";
+    int pos_x = wl_fixed_to_int(sx);
+    int pos_y = wl_fixed_to_int(sy);
 
-    window->input.mouse.x = wl_fixed_to_int(sx);
-    window->input.mouse.y = wl_fixed_to_int(sy);
+    if (!surface)
+    {
+        app->pointer_obj = NULL;
+        return;
+    }
+
+    app->pointer_obj = wl_surface_get_user_data(surface);
+
+    app->pointer_obj->input.pointer.x = pos_x;
+    app->pointer_obj->input.pointer.y = pos_y;
+
+#if (LV_WAYLAND_CLIENT_SIDE_DECORATIONS && LV_WAYLAND_XDG_SHELL)
+    if (!app->pointer_obj->window->xdg_toplevel || app->opt_disable_decorations)
+    {
+        return;
+    }
+
+    struct window *window = app->pointer_obj->window;
+
+    switch (app->pointer_obj->type)
+    {
+    case OBJECT_BORDER_TOP:
+        if (window->maximized)
+        {
+            // do nothing
+        }
+        else if (pos_x < (BORDER_SIZE * 5))
+        {
+            cursor = "top_left_corner";
+        }
+        else if (pos_x >= (window->width + BORDER_SIZE - (BORDER_SIZE * 5)))
+        {
+            cursor = "top_right_corner";
+        }
+        else
+        {
+            cursor = "top_side";
+        }
+        break;
+    case OBJECT_BORDER_BOTTOM:
+        if (window->maximized)
+        {
+            // do nothing
+        }
+        else if (pos_x < (BORDER_SIZE * 5))
+        {
+            cursor = "bottom_left_corner";
+        }
+        else if (pos_x >= (window->width + BORDER_SIZE - (BORDER_SIZE * 5)))
+        {
+            cursor = "bottom_right_corner";
+        }
+        else
+        {
+            cursor = "bottom_side";
+        }
+        break;
+    case OBJECT_BORDER_LEFT:
+        if (window->maximized)
+        {
+            // do nothing
+        }
+        else if (pos_y < (BORDER_SIZE * 5))
+        {
+            cursor = "top_left_corner";
+        }
+        else if (pos_y >= (window->height + BORDER_SIZE - (BORDER_SIZE * 5)))
+        {
+            cursor = "bottom_left_corner";
+        }
+        else
+        {
+            cursor = "left_side";
+        }
+        break;
+    case OBJECT_BORDER_RIGHT:
+        if (window->maximized)
+        {
+            // do nothing
+        }
+        else if (pos_y < (BORDER_SIZE * 5))
+        {
+            cursor = "top_right_corner";
+        }
+        else if (pos_y >= (window->height + BORDER_SIZE - (BORDER_SIZE * 5)))
+        {
+            cursor = "bottom_right_corner";
+        }
+        else
+        {
+            cursor = "right_side";
+        }
+        break;
+    default:
+        break;
+    }
+#endif
+
+    if (app->cursor_surface)
+    {
+        struct wl_cursor_image *cursor_image = wl_cursor_theme_get_cursor(app->cursor_theme, cursor)->images[0];
+        wl_pointer_set_cursor(pointer, serial, app->cursor_surface, cursor_image->hotspot_x, cursor_image->hotspot_y);
+        wl_surface_attach(app->cursor_surface, wl_cursor_image_get_buffer(cursor_image), 0, 0);
+        wl_surface_damage(app->cursor_surface, 0, 0, cursor_image->width, cursor_image->height);
+        wl_surface_commit(app->cursor_surface);
+        app->cursor_flush_pending = true;
+    }
 }
 
 static void pointer_handle_leave(void *data, struct wl_pointer *pointer,
                                  uint32_t serial, struct wl_surface *surface)
 {
     struct application *app = data;
-    struct window *window = wl_surface_get_user_data(surface);
 
-    if (app->pointer_window == window) {
-        app->pointer_window = NULL;
+    if (!surface || (app->pointer_obj == wl_surface_get_user_data(surface)))
+    {
+        app->pointer_obj = NULL;
     }
 }
 
@@ -660,13 +431,15 @@ static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
                                   uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
 {
     struct application *app = data;
-    struct window *window = app->pointer_window;
+    int max_x, max_y;
 
-    if (!window)
+    if (!app->pointer_obj)
+    {
         return;
+    }
 
-    window->input.mouse.x = wl_fixed_to_int(sx);
-    window->input.mouse.y = wl_fixed_to_int(sy);
+    app->pointer_obj->input.pointer.x = LV_MAX(0, LV_MIN(wl_fixed_to_int(sx), app->pointer_obj->width - 1));
+    app->pointer_obj->input.pointer.y = LV_MAX(0, LV_MIN(wl_fixed_to_int(sy), app->pointer_obj->height - 1));
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
@@ -674,23 +447,190 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
                                   uint32_t state)
 {
     struct application *app = data;
-    struct window *window = app->pointer_window;
     const lv_indev_state_t lv_state =
         (state == WL_POINTER_BUTTON_STATE_PRESSED) ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
 
-    if (!window)
+    if (!app->pointer_obj)
+    {
         return;
+    }
 
-    switch (button & 0xF) {
-    case 0:
-        window->input.mouse.left_button = lv_state;
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    struct window *window = app->pointer_obj->window;
+    int pos_x = app->pointer_obj->input.pointer.x;
+    int pos_y = app->pointer_obj->input.pointer.y;
+#endif
+
+    switch (app->pointer_obj->type)
+    {
+    case OBJECT_WINDOW:
+        switch (button)
+        {
+        case BTN_LEFT:
+            app->pointer_obj->input.pointer.left_button = lv_state;
+            break;
+        case BTN_RIGHT:
+            app->pointer_obj->input.pointer.right_button = lv_state;
+            break;
+        case BTN_MIDDLE:
+            app->pointer_obj->input.pointer.wheel_button = lv_state;
+            break;
+        default:
+            break;
+        }
         break;
-    case 1:
-        window->input.mouse.right_button = lv_state;
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    case OBJECT_TITLEBAR:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_PRESSED))
+        {
+#if LV_WAYLAND_XDG_SHELL
+            if (window->xdg_toplevel)
+            {
+                xdg_toplevel_move(window->xdg_toplevel, app->wl_seat, serial);
+                window->flush_pending = true;
+            }
+#endif
+#if LV_WAYLAND_WL_SHELL
+            if (window->wl_shell_surface)
+            {
+                wl_shell_surface_move(window->wl_shell_surface, app->wl_seat, serial);
+                window->flush_pending = true;
+            }
+#endif
+        }
         break;
-    case 2:
-        window->input.mouse.wheel_button = lv_state;
+    case OBJECT_BUTTON_CLOSE:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_RELEASED))
+        {
+            window->shall_close = true;
+        }
         break;
+#if LV_WAYLAND_XDG_SHELL
+    case OBJECT_BUTTON_MAXIMIZE:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_RELEASED))
+        {
+            if (window->xdg_toplevel)
+            {
+                if (window->maximized)
+                {
+                    xdg_toplevel_unset_maximized(window->xdg_toplevel);
+                }
+                else
+                {
+                    xdg_toplevel_set_maximized(window->xdg_toplevel);
+                }
+                window->maximized ^= true;
+            }
+        }
+        break;
+    case OBJECT_BUTTON_MINIMIZE:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_RELEASED))
+        {
+            if (window->xdg_toplevel)
+            {
+                xdg_toplevel_set_minimized(window->xdg_toplevel);
+                window->flush_pending = true;
+            }
+        }
+        break;
+    case OBJECT_BORDER_TOP:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_PRESSED))
+        {
+            if (window->xdg_toplevel && !window->maximized)
+            {
+                uint32_t edge;
+                if (pos_x < (BORDER_SIZE * 5))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+                }
+                else if (pos_x >= (window->width + BORDER_SIZE - (BORDER_SIZE * 5)))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+                }
+                else
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_TOP;
+                }
+                xdg_toplevel_resize(window->xdg_toplevel,
+                                    window->application->wl_seat, serial, edge);
+                window->flush_pending = true;
+            }
+        }
+        break;
+    case OBJECT_BORDER_BOTTOM:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_PRESSED))
+        {
+            if (window->xdg_toplevel && !window->maximized)
+            {
+                uint32_t edge;
+                if (pos_x < (BORDER_SIZE * 5))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+                }
+                else if (pos_x >= (window->width + BORDER_SIZE - (BORDER_SIZE * 5)))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+                }
+                else
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+                }
+                xdg_toplevel_resize(window->xdg_toplevel,
+                                    window->application->wl_seat, serial, edge);
+                window->flush_pending = true;
+            }
+        }
+        break;
+    case OBJECT_BORDER_LEFT:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_PRESSED))
+        {
+            if (window->xdg_toplevel && !window->maximized)
+            {
+                uint32_t edge;
+                if (pos_y < (BORDER_SIZE * 5))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+                }
+                else if (pos_y >= (window->height + BORDER_SIZE - (BORDER_SIZE * 5)))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+                }
+                else
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
+                }
+                xdg_toplevel_resize(window->xdg_toplevel,
+                                    window->application->wl_seat, serial, edge);
+                window->flush_pending = true;
+            }
+        }
+        break;
+    case OBJECT_BORDER_RIGHT:
+        if ((button == BTN_LEFT) && (state == WL_POINTER_BUTTON_STATE_PRESSED))
+        {
+            if (window->xdg_toplevel && !window->maximized)
+            {
+                uint32_t edge;
+                if (pos_y < (BORDER_SIZE * 5))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+                }
+                else if (pos_y >= (window->height + BORDER_SIZE - (BORDER_SIZE * 5)))
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+                }
+                else
+                {
+                    edge = XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
+                }
+                xdg_toplevel_resize(window->xdg_toplevel,
+                                    window->application->wl_seat, serial, edge);
+                window->flush_pending = true;
+            }
+        }
+        break;
+#endif // LV_WAYLAND_XDG_SHELL
+#endif // LV_WAYLAND_CLIENT_SIDE_DECORATIONS
     default:
         break;
     }
@@ -700,188 +640,48 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
                                 uint32_t time, uint32_t axis, wl_fixed_t value)
 {
     struct application *app = data;
-    struct window *window = app->pointer_window;
     const int diff = wl_fixed_to_int(value);
 
-    if (!window)
+    if (!app->pointer_obj)
+    {
         return;
+    }
 
-    if (axis == 0) {
-        if (diff > 0) {
-            window->input.mouse.wheel_diff++;
-        } else if (diff < 0) {
-            window->input.mouse.wheel_diff--;
+    if (axis == 0)
+    {
+        if (diff > 0)
+        {
+            app->pointer_obj->input.pointer.wheel_diff++;
+        }
+        else if (diff < 0)
+        {
+            app->pointer_obj->input.pointer.wheel_diff--;
         }
     }
 }
 
-static void keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,
-                                   uint32_t format, int fd, uint32_t size)
-{
-    struct application *app = data;
-
-    struct xkb_keymap *keymap;
-    struct xkb_state *state;
-    char *map_str;
-
-    if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
-        close(fd);
-        return;
-    }
-
-    map_str = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
-    if (map_str == MAP_FAILED) {
-        close(fd);
-        return;
-    }
-
-    /* Set up XKB keymap */
-    keymap = xkb_keymap_new_from_string(app->xkb_context, map_str,
-                                        XKB_KEYMAP_FORMAT_TEXT_V1, 0);
-    munmap(map_str, size);
-    close(fd);
-
-    if (!keymap) {
-        LV_LOG_ERROR("failed to compile keymap\n");
-        return;
-    }
-
-    /* Set up XKB state */
-    state = xkb_state_new(keymap);
-    if (!state) {
-        LV_LOG_ERROR("failed to create XKB state\n");
-        xkb_keymap_unref(keymap);
-        return;
-    }
-
-    xkb_keymap_unref(app->seat.xkb.keymap);
-    xkb_state_unref(app->seat.xkb.state);
-    app->seat.xkb.keymap = keymap;
-    app->seat.xkb.state = state;
-}
-
-static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard,
-                                  uint32_t serial, struct wl_surface *surface,
-                                  struct wl_array *keys)
-{
-    struct application *app = data;
-    struct window *window = wl_surface_get_user_data(surface);
-    app->keyboard_window = window;
-}
-
-static void keyboard_handle_leave(void *data, struct wl_keyboard *keyboard,
-                                  uint32_t serial, struct wl_surface *surface)
-{
-    struct application *app = data;
-    struct window *window = wl_surface_get_user_data(surface);
-
-    if (app->keyboard_window == window) {
-        app->keyboard_window = NULL;
-    }
-}
-
-static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard,
-                                uint32_t serial, uint32_t time, uint32_t key,
-                                uint32_t state)
-{
-    struct application *app = data;
-    struct window *window = app->keyboard_window;
-
-    if (!window)
-        return;
-
-    const uint32_t code = (key + 8);
-    const xkb_keysym_t *syms;
-    xkb_keysym_t sym = XKB_KEY_NoSymbol;
-
-    if (!app->seat.xkb.state)
-        return;
-
-    if (xkb_state_key_get_syms(app->seat.xkb.state, code, &syms) == 1) {
-        sym = syms[0];
-    }
-
-    const lv_key_t lv_key = keycode_xkb_to_lv(sym);
-    const lv_indev_state_t lv_state =
-        (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
-
-    if (lv_key != 0) {
-        window->input.keyboard.key = lv_key;
-        window->input.keyboard.state = lv_state;
-    }
-}
-
-static void keyboard_handle_modifiers(void *data, struct wl_keyboard *keyboard,
-                                      uint32_t serial, uint32_t mods_depressed,
-                                      uint32_t mods_latched, uint32_t mods_locked,
-                                      uint32_t group)
-{
-    struct application *app = data;
-
-    /* If we're not using a keymap, then we don't handle PC-style modifiers */
-    if (!app->seat.xkb.keymap)
-        return;
-
-    xkb_state_update_mask(app->seat.xkb.state,
-                          mods_depressed, mods_latched, mods_locked, 0, 0, group);
-}
-
-static void touch_handle_down(void *data, struct wl_touch *wl_touch,
-                              uint32_t serial, uint32_t time, struct wl_surface *surface,
-                              int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
-{
-    struct application *app = data;
-    struct window *window = wl_surface_get_user_data(surface);
-
-    app->touch_window = window;
-
-    window->input.touch.x = wl_fixed_to_int(x_w);
-    window->input.touch.y = wl_fixed_to_int(y_w);
-    window->input.touch.state = LV_INDEV_STATE_PR;
-}
-
-static void touch_handle_up(void *data, struct wl_touch *wl_touch,
-                            uint32_t serial, uint32_t time, int32_t id)
-{
-    struct application *app = data;
-    struct window *window = app->touch_window;
-
-    if (!window)
-        return;
-
-    window->input.touch.state = LV_INDEV_STATE_REL;
-}
-
-static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
-                                uint32_t time, int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
-{
-    struct application *app = data;
-    struct window *window = app->touch_window;
-
-    if (!window)
-        return;
-
-    window->input.touch.x = wl_fixed_to_int(x_w);
-    window->input.touch.y = wl_fixed_to_int(y_w);
-}
-
-static void touch_handle_frame(void *data, struct wl_touch *wl_touch)
-{
-}
-
-static void touch_handle_cancel(void *data, struct wl_touch *wl_touch)
-{
-}
+static const struct wl_pointer_listener pointer_listener = {
+    .enter  = pointer_handle_enter,
+    .leave  = pointer_handle_leave,
+    .motion = pointer_handle_motion,
+    .button = pointer_handle_button,
+    .axis   = pointer_handle_axis,
+};
 
 static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key)
 {
     lv_key_t key = 0;
 
-    if (((xkb_key >= XKB_KEY_space) && (xkb_key <= XKB_KEY_asciitilde))) {
-        key = xkb_key; 
-    } else if (((xkb_key >= XKB_KEY_KP_0) && (xkb_key <= XKB_KEY_KP_9))) {
+    if (((xkb_key >= XKB_KEY_space) && (xkb_key <= XKB_KEY_asciitilde)))
+    {
+        key = xkb_key;
+    }
+    else if (((xkb_key >= XKB_KEY_KP_0) && (xkb_key <= XKB_KEY_KP_9)))
+    {
         key = (xkb_key & 0x003f);
-    } else {
+    }
+    else
+    {
         switch (xkb_key)
         {
         case XKB_KEY_BackSpace:
@@ -940,4 +740,1520 @@ static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key)
     return key;
 }
 
-#endif /* USE_WAYLAND */
+static void keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,
+                                   uint32_t format, int fd, uint32_t size)
+{
+    struct application *app = data;
+
+    struct xkb_keymap *keymap;
+    struct xkb_state *state;
+    char *map_str;
+
+    if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1)
+    {
+        close(fd);
+        return;
+    }
+
+    map_str = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (map_str == MAP_FAILED)
+    {
+        close(fd);
+        return;
+    }
+
+    /* Set up XKB keymap */
+    keymap = xkb_keymap_new_from_string(app->xkb_context, map_str,
+                                        XKB_KEYMAP_FORMAT_TEXT_V1, 0);
+    munmap(map_str, size);
+    close(fd);
+
+    if (!keymap)
+    {
+        LV_LOG_ERROR("failed to compile keymap\n");
+        return;
+    }
+
+    /* Set up XKB state */
+    state = xkb_state_new(keymap);
+    if (!state)
+    {
+        LV_LOG_ERROR("failed to create XKB state\n");
+        xkb_keymap_unref(keymap);
+        return;
+    }
+
+    xkb_keymap_unref(app->seat.xkb.keymap);
+    xkb_state_unref(app->seat.xkb.state);
+    app->seat.xkb.keymap = keymap;
+    app->seat.xkb.state = state;
+}
+
+static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard,
+                                  uint32_t serial, struct wl_surface *surface,
+                                  struct wl_array *keys)
+{
+    struct application *app = data;
+
+    if (!surface)
+    {
+        app->keyboard_obj = NULL;
+    }
+    else
+    {
+        app->keyboard_obj = wl_surface_get_user_data(surface);
+    }
+}
+
+static void keyboard_handle_leave(void *data, struct wl_keyboard *keyboard,
+                                  uint32_t serial, struct wl_surface *surface)
+{
+    struct application *app = data;
+
+    if (!surface || (app->keyboard_obj == wl_surface_get_user_data(surface)))
+    {
+        app->keyboard_obj = NULL;
+    }
+}
+
+static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard,
+                                uint32_t serial, uint32_t time, uint32_t key,
+                                uint32_t state)
+{
+    struct application *app = data;
+    const uint32_t code = (key + 8);
+    const xkb_keysym_t *syms;
+    xkb_keysym_t sym = XKB_KEY_NoSymbol;
+
+    if (!app->keyboard_obj || !app->seat.xkb.state)
+    {
+        return;
+    }
+
+    if (xkb_state_key_get_syms(app->seat.xkb.state, code, &syms) == 1)
+    {
+        sym = syms[0];
+    }
+
+    const lv_key_t lv_key = keycode_xkb_to_lv(sym);
+    const lv_indev_state_t lv_state =
+        (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
+
+    if (lv_key != 0)
+    {
+        app->keyboard_obj->input.keyboard.key = lv_key;
+        app->keyboard_obj->input.keyboard.state = lv_state;
+    }
+}
+
+static void keyboard_handle_modifiers(void *data, struct wl_keyboard *keyboard,
+                                      uint32_t serial, uint32_t mods_depressed,
+                                      uint32_t mods_latched, uint32_t mods_locked,
+                                      uint32_t group)
+{
+    struct application *app = data;
+
+    /* If we're not using a keymap, then we don't handle PC-style modifiers */
+    if (!app->seat.xkb.keymap)
+    {
+        return;
+    }
+
+    xkb_state_update_mask(app->seat.xkb.state,
+                          mods_depressed, mods_latched, mods_locked, 0, 0, group);
+}
+
+static const struct wl_keyboard_listener keyboard_listener = {
+    .keymap     = keyboard_handle_keymap,
+    .enter      = keyboard_handle_enter,
+    .leave      = keyboard_handle_leave,
+    .key        = keyboard_handle_key,
+    .modifiers  = keyboard_handle_modifiers,
+};
+
+static void touch_handle_down(void *data, struct wl_touch *wl_touch,
+                              uint32_t serial, uint32_t time, struct wl_surface *surface,
+                              int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
+{
+    struct application *app = data;
+
+    if (!surface)
+    {
+        app->touch_obj = NULL;
+        return;
+    }
+
+    app->touch_obj = wl_surface_get_user_data(surface);
+
+    app->touch_obj->input.touch.x = wl_fixed_to_int(x_w);
+    app->touch_obj->input.touch.y = wl_fixed_to_int(y_w);
+    app->touch_obj->input.touch.state = LV_INDEV_STATE_PR;
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    struct window *window = app->touch_obj->window;
+    switch (app->touch_obj->type)
+    {
+    case OBJECT_TITLEBAR:
+#if LV_WAYLAND_XDG_SHELL
+        if (window->xdg_toplevel)
+        {
+            xdg_toplevel_move(window->xdg_toplevel, app->wl_seat, serial);
+            window->flush_pending = true;
+        }
+#endif
+#if LV_WAYLAND_WL_SHELL
+        if (window->wl_shell_surface)
+        {
+            wl_shell_surface_move(window->wl_shell_surface, app->wl_seat, serial);
+            window->flush_pending = true;
+        }
+#endif
+        break;
+    default:
+        break;
+    }
+#endif
+}
+
+static void touch_handle_up(void *data, struct wl_touch *wl_touch,
+                            uint32_t serial, uint32_t time, int32_t id)
+{
+    struct application *app = data;
+
+    if (!app->touch_obj)
+    {
+        return;
+    }
+
+    app->touch_obj->input.touch.state = LV_INDEV_STATE_REL;
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    struct window *window = app->touch_obj->window;
+    switch (app->touch_obj->type)
+    {
+    case OBJECT_BUTTON_CLOSE:
+        window->shall_close = true;
+        break;
+#if LV_WAYLAND_XDG_SHELL
+    case OBJECT_BUTTON_MAXIMIZE:
+        if (window->xdg_toplevel)
+        {
+            if (window->maximized)
+            {
+                xdg_toplevel_unset_maximized(window->xdg_toplevel);
+            }
+            else
+            {
+                xdg_toplevel_set_maximized(window->xdg_toplevel);
+            }
+            window->maximized ^= true;
+        }
+        break;
+    case OBJECT_BUTTON_MINIMIZE:
+        if (window->xdg_toplevel)
+        {
+            xdg_toplevel_set_minimized(window->xdg_toplevel);
+            window->flush_pending = true;
+        }
+#endif // LV_WAYLAND_XDG_SHELL
+    default:
+        break;
+    }
+#endif // LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+
+    app->touch_obj = NULL;
+}
+
+static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
+                                uint32_t time, int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
+{
+    struct application *app = data;
+
+    if (!app->touch_obj)
+    {
+        return;
+    }
+
+    app->touch_obj->input.touch.x = wl_fixed_to_int(x_w);
+    app->touch_obj->input.touch.y = wl_fixed_to_int(y_w);
+}
+
+static void touch_handle_frame(void *data, struct wl_touch *wl_touch)
+{
+}
+
+static void touch_handle_cancel(void *data, struct wl_touch *wl_touch)
+{
+}
+
+static const struct wl_touch_listener touch_listener = {
+    .down   = touch_handle_down,
+    .up     = touch_handle_up,
+    .motion = touch_handle_motion,
+    .frame  = touch_handle_frame,
+    .cancel = touch_handle_cancel,
+};
+
+static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat, enum wl_seat_capability caps)
+{
+    struct application *app = data;
+    struct seat *seat = &app->seat;
+
+    if ((caps & WL_SEAT_CAPABILITY_POINTER) && !seat->wl_pointer)
+    {
+        seat->wl_pointer = wl_seat_get_pointer(wl_seat);
+        wl_pointer_add_listener(seat->wl_pointer, &pointer_listener, app);
+        app->cursor_surface = wl_compositor_create_surface(app->compositor);
+        if (!app->cursor_surface)
+        {
+            LV_LOG_WARN("failed to create cursor surface");
+        }
+    }
+    else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && seat->wl_pointer)
+    {
+        wl_pointer_destroy(seat->wl_pointer);
+        if (app->cursor_surface)
+        {
+            wl_surface_destroy(app->cursor_surface);
+        }
+        seat->wl_pointer = NULL;
+    }
+
+    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !seat->wl_keyboard)
+    {
+        seat->wl_keyboard = wl_seat_get_keyboard(wl_seat);
+        wl_keyboard_add_listener(seat->wl_keyboard, &keyboard_listener, app);
+    }
+    else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && seat->wl_keyboard)
+    {
+        wl_keyboard_destroy(seat->wl_keyboard);
+        seat->wl_keyboard = NULL;
+    }
+
+    if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !seat->wl_touch)
+    {
+        seat->wl_touch = wl_seat_get_touch(wl_seat);
+        wl_touch_add_listener(seat->wl_touch, &touch_listener, app);
+    }
+    else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && seat->wl_touch)
+    {
+        wl_touch_destroy(seat->wl_touch);
+        seat->wl_touch = NULL;
+    }
+}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_handle_capabilities,
+};
+
+#if LV_WAYLAND_WL_SHELL
+static void wl_shell_handle_ping(void *data, struct wl_shell_surface *shell_surface, uint32_t serial)
+{
+    return wl_shell_surface_pong(shell_surface, serial);
+}
+
+static void wl_shell_handle_configure(void *data, struct wl_shell_surface *shell_surface,
+                                      uint32_t edges, int32_t width, int32_t height)
+{
+}
+
+static const struct wl_shell_surface_listener shell_surface_listener = {
+    .ping       = wl_shell_handle_ping,
+    .configure  =  wl_shell_handle_configure,
+};
+#endif
+
+#if LV_WAYLAND_XDG_SHELL
+static void xdg_surface_handle_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial)
+{
+    return xdg_surface_ack_configure(xdg_surface, serial);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_handle_configure,
+};
+
+void xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *xdg_toplevel,
+                                   int32_t width, int32_t height, struct wl_array *states)
+{
+    struct window *window = (struct window *)data;
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    if (!window->application->opt_disable_decorations)
+    {
+        width -= (2 * BORDER_SIZE);
+        height -= (TITLE_BAR_HEIGHT + (2 * BORDER_SIZE));
+    }
+#endif
+
+    if ((width <= 0) || (height <= 0))
+    {
+        return;
+    }
+
+    if ((width != window->width) || (height != window->height))
+    {
+        resize_window(window, width, height);
+    }
+}
+
+static void xdg_toplevel_handle_close(void *data, struct xdg_toplevel *xdg_toplevel)
+{
+    struct window *window = (struct window *)data;
+    window->shall_close = true;
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+    .configure = xdg_toplevel_handle_configure,
+    .close = xdg_toplevel_handle_close,
+};
+
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *xdg_wm_base, uint32_t serial)
+{
+    return xdg_wm_base_pong(xdg_wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping
+};
+#endif
+
+static void handle_global(void *data, struct wl_registry *registry,
+                          uint32_t name, const char *interface, uint32_t version)
+{
+    struct application *app = data;
+
+    if (strcmp(interface, wl_compositor_interface.name) == 0)
+    {
+        app->compositor = wl_registry_bind(registry, name, &wl_compositor_interface, 1);
+    }
+    else if (strcmp(interface, wl_subcompositor_interface.name) == 0)
+    {
+        app->subcompositor = wl_registry_bind(registry, name, &wl_subcompositor_interface, 1);
+    }
+    else if (strcmp(interface, wl_shm_interface.name) == 0)
+    {
+        app->shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+        wl_shm_add_listener(app->shm, &shm_listener, app);
+        app->cursor_theme = wl_cursor_theme_load(NULL, 32, app->shm);
+    }
+    else if (strcmp(interface, wl_seat_interface.name) == 0)
+    {
+        app->wl_seat = wl_registry_bind(app->registry, name, &wl_seat_interface, 1);
+        wl_seat_add_listener(app->wl_seat, &seat_listener, app);
+    }
+#if LV_WAYLAND_WL_SHELL
+    else if (strcmp(interface, wl_shell_interface.name) == 0)
+    {
+        app->wl_shell = wl_registry_bind(registry, name, &wl_shell_interface, 1);
+    }
+#endif
+#if LV_WAYLAND_XDG_SHELL
+    else if (strcmp(interface, xdg_wm_base_interface.name) == 0)
+    {
+        app->xdg_wm = wl_registry_bind(app->registry, name, &xdg_wm_base_interface, version);
+        xdg_wm_base_add_listener(app->xdg_wm, &xdg_wm_base_listener, app);
+    }
+#endif
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name)
+{
+
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global         = handle_global,
+    .global_remove  = handle_global_remove
+};
+
+static bool initialize_allocator(struct buffer_allocator *allocator, const char *dir)
+{
+    static const char template[] = "/lvgl-wayland-XXXXXX";
+    char *name;
+
+    // Create file for shared memory allocation
+    name = lv_mem_alloc(strlen(dir) + sizeof(template));
+    LV_ASSERT_MSG(name, "cannot allocate memory for name\n");
+    if (!name)
+    {
+        return false;
+    }
+
+    strcpy(name, dir);
+    strcat(name, template);
+
+    allocator->shm_mem_fd = mkstemp(name);
+
+    lv_mem_free(name);
+
+    LV_ASSERT_MSG((allocator->shm_mem_fd >= 0), "cannot create tmpfile\n");
+    if (allocator->shm_mem_fd < 0)
+    {
+        return false;
+    }
+
+    allocator->shm_mem_size = 0;
+    allocator->shm_file_free_size = 0;
+
+    return true;
+}
+
+static void deinitialize_allocator(struct buffer_allocator *allocator)
+{
+    if (allocator->shm_pool)
+    {
+        wl_shm_pool_destroy(allocator->shm_pool);
+    }
+
+    if (allocator->shm_mem_fd >= 0)
+    {
+        close(allocator->shm_mem_fd);
+        allocator->shm_mem_fd = -1;
+    }
+}
+
+static bool initialize_buffer(struct window *window, struct buffer_hdl *buffer_hdl,
+                              int width, int height)
+{
+    struct application *app = window->application;
+    struct buffer_allocator *allocator = &window->allocator;
+    int allocated_size = 0;
+    int ret;
+    long sz = sysconf(_SC_PAGESIZE);
+
+    buffer_hdl->size = (((width * height * BYTES_PER_PIXEL) + sz - 1) / sz) * sz;
+
+    LV_LOG_TRACE("initializing buffer %dx%d (alloc size: %d)\n",
+                 width, height, buffer_hdl->size);
+
+    if (allocator->shm_file_free_size < buffer_hdl->size)
+    {
+        do
+        {
+            ret = ftruncate(allocator->shm_mem_fd,
+                            allocator->shm_mem_size + (buffer_hdl->size - allocator->shm_file_free_size));
+        }
+        while ((ret < 0) && (errno == EINTR));
+
+        if (ret < 0)
+        {
+            LV_LOG_ERROR("ftruncate failed: %s\n", strerror(errno));
+            goto err_out;
+        }
+        else
+        {
+            allocated_size = (buffer_hdl->size - allocator->shm_file_free_size);
+        }
+
+        LV_ASSERT_MSG((allocated_size >= 0), "allocated_size is negative");
+    }
+
+    buffer_hdl->base = mmap(NULL, buffer_hdl->size,
+                            PROT_READ | PROT_WRITE, MAP_SHARED,
+                            allocator->shm_mem_fd,
+                            allocator->shm_mem_size - allocator->shm_file_free_size);
+    if (buffer_hdl->base == MAP_FAILED)
+    {
+        LV_LOG_ERROR("mmap failed: %s\n", strerror(errno));
+        goto err_inc_free;
+    }
+
+    if (!allocator->shm_pool)
+    {
+        // Create SHM pool
+        allocator->shm_pool = wl_shm_create_pool(app->shm,
+                                                 allocator->shm_mem_fd,
+                                                 allocator->shm_mem_size + allocated_size);
+        if (!allocator->shm_pool)
+        {
+            LV_LOG_ERROR("cannot create shm pool\n");
+            goto err_unmap;
+        }
+    }
+    else if (allocated_size > 0)
+    {
+        // Resize SHM pool
+        wl_shm_pool_resize(allocator->shm_pool,
+                           allocator->shm_mem_size + allocated_size);
+    }
+
+    // Create buffer
+    buffer_hdl->wl_buffer = wl_shm_pool_create_buffer(allocator->shm_pool,
+                                                      allocator->shm_mem_size - allocator->shm_file_free_size,
+                                                      width, height,
+                                                      width * BYTES_PER_PIXEL,
+                                                      app->format);
+    if (!buffer_hdl->wl_buffer)
+    {
+        LV_LOG_ERROR("cannot create shm buffer\n");
+        goto err_unmap;
+    }
+
+    /* Update size of SHM */
+    allocator->shm_mem_size += allocated_size;
+    allocator->shm_file_free_size = LV_MAX(0, (allocator->shm_file_free_size - buffer_hdl->size));
+
+    lv_memset_00(buffer_hdl->base, buffer_hdl->size);
+
+    return true;
+
+err_unmap:
+    munmap(buffer_hdl->base, buffer_hdl->size);
+
+err_inc_free:
+    allocator->shm_file_free_size += allocated_size;
+
+err_out:
+    return false;
+}
+
+static bool deinitialize_buffer(struct window *window, struct buffer_hdl *buffer_hdl)
+{
+    struct buffer_allocator *allocator = &window->allocator;
+
+    if (buffer_hdl->wl_buffer)
+    {
+        wl_buffer_destroy(buffer_hdl->wl_buffer);
+        buffer_hdl->wl_buffer = NULL;
+    }
+
+    if (buffer_hdl->size > 0)
+    {
+        munmap(buffer_hdl->base, buffer_hdl->size);
+        allocator->shm_file_free_size += buffer_hdl->size;
+        buffer_hdl->base = 0;
+        buffer_hdl->size = 0;
+    }
+}
+
+static struct graphic_object * create_graphic_obj(struct application *app, struct window *window,
+                                                  enum object_type type,
+                                                  struct graphic_object *parent)
+{
+    struct graphic_object *obj;
+
+    obj = lv_mem_alloc(sizeof(*obj));
+    LV_ASSERT_MALLOC(obj);
+    if (!obj)
+    {
+        return NULL;
+    }
+
+    lv_memset(obj, 0x00, sizeof(struct graphic_object));
+
+    obj->window = window;
+    obj->type = type;
+
+    obj->surface = wl_compositor_create_surface(app->compositor);
+    if (!obj->surface)
+    {
+        LV_LOG_ERROR("cannot create surface for graphic object");
+        goto err_out;
+    }
+
+    wl_surface_set_user_data(obj->surface, obj);
+
+    if (parent != NULL)
+    {
+        obj->subsurface = wl_subcompositor_get_subsurface(app->subcompositor,
+                                                          obj->surface,
+                                                          parent->surface);
+        if (!obj->subsurface)
+        {
+            LV_LOG_ERROR("cannot get subsurface for graphic object");
+            goto err_destroy_surface;
+        }
+
+        wl_subsurface_set_desync(obj->subsurface);
+    }
+
+    return obj;
+
+err_destroy_surface:
+    wl_surface_destroy(obj->surface);
+
+err_free:
+    lv_mem_free(obj);
+
+err_out:
+    return NULL;
+}
+
+static void destroy_graphic_obj(struct graphic_object * obj)
+{
+    wl_surface_destroy(obj->surface);
+
+    lv_mem_free(obj);
+}
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+static bool create_and_attach_decoration(struct window *window,
+                                         struct graphic_object * decoration)
+{
+    int pos_x, pos_y;
+    int x, y;
+
+    switch (decoration->type)
+    {
+    case OBJECT_TITLEBAR:
+        decoration->width = window->width;
+        decoration->height = TITLE_BAR_HEIGHT;
+        pos_x = 0;
+        pos_y = -TITLE_BAR_HEIGHT;
+        break;
+    case OBJECT_BUTTON_CLOSE:
+        decoration->width = BUTTON_SIZE;
+        decoration->height = BUTTON_SIZE;
+        pos_x = window->width - 1 * (BUTTON_MARGIN + BUTTON_SIZE);
+        pos_y = -1 * (BUTTON_MARGIN + BUTTON_SIZE + (BORDER_SIZE / 2));
+        break;
+#if LV_WAYLAND_XDG_SHELL
+    case OBJECT_BUTTON_MAXIMIZE:
+        decoration->width = BUTTON_SIZE;
+        decoration->height = BUTTON_SIZE;
+        pos_x = window->width - 2 * (BUTTON_MARGIN + BUTTON_SIZE);
+        pos_y = -1 * (BUTTON_MARGIN + BUTTON_SIZE + (BORDER_SIZE / 2));
+        break;
+    case OBJECT_BUTTON_MINIMIZE:
+        decoration->width = BUTTON_SIZE;
+        decoration->height = BUTTON_SIZE;
+        pos_x = window->width - 3 * (BUTTON_MARGIN + BUTTON_SIZE);
+        pos_y = -1 * (BUTTON_MARGIN + BUTTON_SIZE + (BORDER_SIZE / 2));
+        break;
+#endif
+    case OBJECT_BORDER_TOP:
+        decoration->width = window->width + 2 * (BORDER_SIZE);
+        decoration->height = BORDER_SIZE;
+        pos_x = -BORDER_SIZE;
+        pos_y = -(BORDER_SIZE + TITLE_BAR_HEIGHT);
+        break;
+    case OBJECT_BORDER_BOTTOM:
+        decoration->width = window->width + 2 * (BORDER_SIZE);
+        decoration->height = BORDER_SIZE;
+        pos_x = -BORDER_SIZE;
+        pos_y = window->height;
+        break;
+    case OBJECT_BORDER_LEFT:
+        decoration->width = BORDER_SIZE;
+        decoration->height = window->height + TITLE_BAR_HEIGHT;
+        pos_x = -BORDER_SIZE;
+        pos_y = -TITLE_BAR_HEIGHT;
+        break;
+    case OBJECT_BORDER_RIGHT:
+        decoration->width = BORDER_SIZE;
+        decoration->height = window->height + TITLE_BAR_HEIGHT;
+        pos_x = window->width;
+        pos_y = -TITLE_BAR_HEIGHT;
+        break;
+    default:
+        LV_ASSERT_MSG(0, "Invalid object type");
+        return false;
+    }
+
+    if (!initialize_buffer(window, &decoration->buffer, decoration->width, decoration->height))
+    {
+        LV_LOG_ERROR("cannot create buffer for decoration");
+        return false;
+    }
+
+    switch (decoration->type)
+    {
+    case OBJECT_TITLEBAR:
+        lv_color_fill((lv_color_t *)decoration->buffer.base,
+                      lv_color_make(0x66, 0x66, 0x66), (decoration->width * decoration->height));
+        break;
+    case OBJECT_BUTTON_CLOSE:
+        lv_color_fill((lv_color_t *)decoration->buffer.base,
+                      lv_color_make(0xCC, 0xCC, 0xCC), (decoration->width * decoration->height));
+        for (y = 0; y < decoration->height; y++)
+        {
+            for (x = 0; x < decoration->width; x++)
+            {
+                lv_color_t *pixel = ((lv_color_t *)decoration->buffer.base + (y * decoration->width) + x);
+                if ((x >= BUTTON_PADDING) && (x < decoration->width - BUTTON_PADDING))
+                {
+                    if ((x == y) || (x == decoration->width - 1 - y))
+                    {
+                        *pixel = lv_color_make(0x33, 0x33, 0x33);
+                    }
+                    else if ((x == y - 1) || (x == decoration->width - y))
+                    {
+                        *pixel = lv_color_make(0x66, 0x66, 0x66);
+                    }
+                }
+            }
+        }
+        break;
+#if LV_WAYLAND_XDG_SHELL
+    case OBJECT_BUTTON_MAXIMIZE:
+        lv_color_fill((lv_color_t *)decoration->buffer.base,
+                      lv_color_make(0xCC, 0xCC, 0xCC), (decoration->width * decoration->height));
+        for (y = 0; y < decoration->height; y++)
+        {
+            for (x = 0; x < decoration->width; x++)
+            {
+                lv_color_t *pixel = ((lv_color_t *)decoration->buffer.base + (y * decoration->width) + x);
+                if (((x == BUTTON_PADDING) && (y >= BUTTON_PADDING) && (y < decoration->height - BUTTON_PADDING)) ||
+                    ((x == (decoration->width - BUTTON_PADDING)) && (y >= BUTTON_PADDING) && (y <= decoration->height - BUTTON_PADDING)) ||
+                    ((y == BUTTON_PADDING) && (x >= BUTTON_PADDING) && (x < decoration->width - BUTTON_PADDING)) ||
+                    ((y == (BUTTON_PADDING + 1)) && (x >= BUTTON_PADDING) && (x < decoration->width - BUTTON_PADDING)) ||
+                    ((y == (decoration->height - BUTTON_PADDING)) && (x >= BUTTON_PADDING) && (x < decoration->width - BUTTON_PADDING)))
+                {
+                    *pixel = lv_color_make(0x33, 0x33, 0x33);
+                }
+            }
+        }
+        break;
+    case OBJECT_BUTTON_MINIMIZE:
+        lv_color_fill((lv_color_t *)decoration->buffer.base,
+                      lv_color_make(0xCC, 0xCC, 0xCC), (decoration->width * decoration->height));
+        for (y = 0; y < decoration->height; y++)
+        {
+            for (x = 0; x < decoration->width; x++)
+            {
+                lv_color_t *pixel = ((lv_color_t *)decoration->buffer.base + (y * decoration->width) + x);
+                if ((x >= BUTTON_PADDING) && (x < decoration->width - BUTTON_PADDING) &&
+                    (y > decoration->height - (2 * BUTTON_PADDING)) && (y < decoration->height - BUTTON_PADDING))
+                {
+                    *pixel = lv_color_make(0x33, 0x33, 0x33);
+                }
+            }
+        }
+        break;
+#endif
+    case OBJECT_BORDER_TOP:
+        /* fallthrough */
+    case OBJECT_BORDER_BOTTOM:
+        /* fallthrough */
+    case OBJECT_BORDER_LEFT:
+        /* fallthrough */
+    case OBJECT_BORDER_RIGHT:
+        lv_color_fill((lv_color_t *)decoration->buffer.base,
+                      lv_color_make(0x66, 0x66, 0x66), (decoration->width * decoration->height));
+        break;
+    default:
+        LV_ASSERT_MSG(0, "Invalid object type");
+        return false;
+    }
+
+    wl_surface_attach(decoration->surface, decoration->buffer.wl_buffer, 0, 0);
+    wl_surface_commit(decoration->surface);
+
+    wl_subsurface_set_position(decoration->subsurface, pos_x, pos_y);
+
+    return true;
+}
+#endif
+
+static bool resize_window(struct window *window, int width, int height)
+{
+    LV_LOG_TRACE("resize window %dx%d\n", width, height);
+
+    // De-initialize previous buffers
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    int b;
+    for (b = 0; b < NUM_DECORATIONS; b++)
+    {
+        if (window->decoration[b])
+        {
+            deinitialize_buffer(window, &window->decoration[b]->buffer);
+        }
+    }
+#endif
+    deinitialize_buffer(window, &window->body->buffer);
+
+    // Initialize backing buffer
+    if (!initialize_buffer(window, &window->body->buffer, width, height))
+    {
+        LV_LOG_ERROR("failed to initialize window buffer\n");
+        return false;
+    }
+
+    window->width = width;
+    window->height = height;
+
+    window->body->width = width;
+    window->body->height = height;
+
+    wl_surface_attach(window->body->surface, window->body->buffer.wl_buffer, 0, 0);
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    if (!window->application->opt_disable_decorations)
+    {
+        for (b = 0; b < NUM_DECORATIONS; b++)
+        {
+            if (!create_and_attach_decoration(window, window->decoration[b]))
+            {
+                LV_LOG_ERROR("failed to create decoration %d\n", b);
+            }
+        }
+    }
+#endif
+
+    if (window->lv_disp != NULL)
+    {
+        // Propagate resize to upper layers
+        window->lv_disp_drv.hor_res = width;
+        window->lv_disp_drv.ver_res = height;
+        lv_disp_drv_update(window->lv_disp, &window->lv_disp_drv);
+
+        window->body->input.pointer.x = LV_MIN(window->body->input.pointer.x, (width - 1));
+        window->body->input.pointer.y = LV_MIN(window->body->input.pointer.y, (height - 1));
+    }
+
+    return true;
+}
+
+static struct window *create_window(struct application *app, int width, int height, const char *title)
+{
+    struct window *window;
+
+    window = _lv_ll_ins_tail(&app->window_ll);
+    LV_ASSERT_MALLOC(window);
+    if (!window)
+    {
+        return NULL;
+    }
+
+    lv_memset(window, 0x00, sizeof(struct window));
+
+    window->application = app;
+
+    // Initialize buffer allocator
+    if (!initialize_allocator(&window->allocator, app->xdg_runtime_dir))
+    {
+        LV_LOG_ERROR("cannot init memory allocator");
+        goto err_free_window;
+    }
+
+    // Create wayland buffer and surface
+    window->body = create_graphic_obj(app, window, OBJECT_WINDOW, NULL);
+    if (!window->body)
+    {
+        LV_LOG_ERROR("cannot create window body");
+        goto err_deinit_allocator;
+    }
+
+    // Create shell surface
+     if (0)
+    {
+        // Needed for #if madness below
+    }
+#if LV_WAYLAND_XDG_SHELL
+    else if (app->xdg_wm)
+    {
+        window->xdg_surface = xdg_wm_base_get_xdg_surface(app->xdg_wm, window->body->surface);
+        if (!window->xdg_surface)
+        {
+            LV_LOG_ERROR("cannot create XDG surface");
+            goto err_destroy_surface;
+        }
+
+        xdg_surface_add_listener(window->xdg_surface, &xdg_surface_listener, window);
+
+        window->xdg_toplevel = xdg_surface_get_toplevel(window->xdg_surface);
+        if (!window->xdg_toplevel)
+        {
+            LV_LOG_ERROR("cannot get XDG toplevel surface");
+            goto err_destroy_shell_surface;
+        }
+
+        xdg_toplevel_add_listener(window->xdg_toplevel, &xdg_toplevel_listener, window);
+        xdg_toplevel_set_title(window->xdg_toplevel, title);
+        xdg_toplevel_set_app_id(window->xdg_toplevel, title);
+    }
+#endif
+#if LV_WAYLAND_WL_SHELL
+    else if (app->wl_shell)
+    {
+        window->wl_shell_surface = wl_shell_get_shell_surface(app->wl_shell, window->body->surface);
+        if (!window->wl_shell_surface)
+        {
+            LV_LOG_ERROR("cannot create WL shell surface");
+            goto err_destroy_surface;
+        }
+
+        wl_shell_surface_add_listener(window->wl_shell_surface, &shell_surface_listener, &window);
+        wl_shell_surface_set_toplevel(window->wl_shell_surface);
+        wl_shell_surface_set_title(window->wl_shell_surface, title);
+    }
+#endif
+    else
+    {
+        LV_LOG_ERROR("No shell available");
+        goto err_destroy_surface;
+    }
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    if (!app->opt_disable_decorations)
+    {
+        int d;
+        for (d = 0; d < NUM_DECORATIONS; d++)
+        {
+            window->decoration[d] = create_graphic_obj(app, window, (FIRST_DECORATION+d), window->body);
+            if (!window->decoration[d])
+            {
+                LV_LOG_ERROR("Failed to create decoration %d", d);
+            }
+        }
+    }
+#endif
+
+    if (!resize_window(window, width, height))
+    {
+        LV_LOG_ERROR("Failed to resize window");
+        goto err_destroy_shell_surface2;
+    }
+
+    return window;
+
+err_destroy_shell_surface2:
+#if LV_WAYLAND_XDG_SHELL
+    if (window->xdg_toplevel)
+    {
+        xdg_toplevel_destroy(window->xdg_toplevel);
+    }
+#endif
+
+err_destroy_shell_surface:
+#if LV_WAYLAND_WL_SHELL
+    if (window->wl_shell_surface)
+    {
+        wl_shell_surface_destroy(window->wl_shell_surface);
+    }
+#endif
+#if LV_WAYLAND_XDG_SHELL
+    if (window->xdg_surface)
+    {
+        xdg_surface_destroy(window->xdg_surface);
+    }
+#endif
+
+err_destroy_surface:
+    wl_surface_destroy(window->body->surface);
+
+err_deinit_allocator:
+    deinitialize_allocator(&window->allocator);
+
+err_free_window:
+    _lv_ll_remove(&app->window_ll, window);
+    lv_mem_free(window);
+    return NULL;
+}
+
+static void destroy_window(struct window *window)
+{
+    if (!window)
+    {
+        return;
+    }
+
+#if LV_WAYLAND_WL_SHELL
+    if (window->wl_shell_surface)
+    {
+        wl_shell_surface_destroy(window->wl_shell_surface);
+    }
+#endif
+#if LV_WAYLAND_XDG_SHELL
+    if (window->xdg_toplevel)
+    {
+        xdg_toplevel_destroy(window->xdg_toplevel);
+        xdg_surface_destroy(window->xdg_surface);
+    }
+#endif
+
+#if LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    int b;
+    for (b = 0; b < NUM_DECORATIONS; b++)
+    {
+        if (window->decoration[b])
+        {
+            deinitialize_buffer(window, &window->decoration[b]->buffer);
+            destroy_graphic_obj(window->decoration[b]);
+            window->decoration[b] = NULL;
+        }
+    }
+#endif
+
+    deinitialize_buffer(window, &window->body->buffer);
+    destroy_graphic_obj(window->body);
+
+    deinitialize_allocator(&window->allocator);
+}
+
+static void _lv_wayland_flush(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv_color_t *color_p)
+{
+    struct window *window = disp_drv->user_data;
+    lv_coord_t hres = (disp_drv->rotated == 0) ? (disp_drv->hor_res) : (disp_drv->ver_res);
+    lv_coord_t vres = (disp_drv->rotated == 0) ? (disp_drv->ver_res) : (disp_drv->hor_res);
+
+    /* If private data is not set, it means window has not been initialized */
+    if (!window)
+    {
+        LV_LOG_ERROR("please intialize wayland display using lv_wayland_create_window()\n");
+        return;
+    }
+    /* If window has been / is being closed, or is not visible, skip rendering */
+    else if (window->closed || window->shall_close)
+    {
+        lv_disp_flush_ready(disp_drv);
+        return;
+    }
+    /* Return if the area is out the screen */
+    else if ((area->x2 < 0) || (area->y2 < 0) || (area->x1 > hres - 1) || (area->y1 > vres - 1))
+    {
+        lv_disp_flush_ready(disp_drv);
+        return;
+    }
+
+    int32_t x;
+    int32_t y;
+
+    for (y = area->y1; y <= area->y2 && y < disp_drv->ver_res; y++)
+    {
+        for (x = area->x1; x <= area->x2 && x < disp_drv->hor_res; x++)
+        {
+            int offset = (y * disp_drv->hor_res) + x;
+#if (LV_COLOR_DEPTH == 32)
+            uint32_t * const buf = (uint32_t *)window->body->buffer.base + offset;
+            *buf = color_p->full;
+#elif (LV_COLOR_DEPTH == 16)
+            uint16_t * const buf = (uint16_t *)window->body->buffer.base + offset;
+            *buf = color_p->full;
+#elif (LV_COLOR_DEPTH == 8)
+            uint8_t * const buf = (uint8_t *)window->body->buffer.base + offset;
+            *buf = color_p->full;
+#elif (LV_COLOR_DEPTH == 1)
+            uint8_t * const buf = (uint8_t *)window->body->buffer.base + offset;
+            *buf = ((0x07 * color_p->ch.red)   << 5) |
+                   ((0x07 * color_p->ch.green) << 2) |
+                   ((0x03 * color_p->ch.blue)  << 0);
+#endif
+            color_p++;
+        }
+    }
+
+    wl_surface_damage(window->body->surface, area->x1, area->y1,
+                      (area->x2 - area->x1 + 1), (area->y2 - area->y1 + 1));
+
+    if (lv_disp_flush_is_last(disp_drv))
+    {
+        wl_surface_commit(window->body->surface);
+        window->flush_pending = true;
+    }
+
+    lv_disp_flush_ready(disp_drv);
+}
+
+static void _lv_wayland_cycle(lv_timer_t * tmr)
+{
+    struct window *window = NULL;
+    bool shall_flush = application.cursor_flush_pending;
+
+    LV_UNUSED(tmr);
+
+    while (wl_display_prepare_read(application.display) != 0)
+    {
+        wl_display_dispatch_pending(application.display);
+    }
+
+    _LV_LL_READ(&application.window_ll, window)
+    {
+        if ((window->shall_close) && (window->close_cb != NULL))
+        {
+            window->shall_close = window->close_cb(window->lv_disp);
+        }
+
+        if (window->shall_close)
+        {
+            destroy_window(window);
+            window->closed = true;
+            window->shall_close = false;
+            shall_flush = true;
+
+            window->body->input.touch.x = 0;
+            window->body->input.touch.y = 0;
+            window->body->input.touch.state = LV_INDEV_STATE_RELEASED;
+            if (window->application->touch_obj == window->body)
+            {
+                window->application->touch_obj = NULL;
+            }
+
+            window->body->input.pointer.x = 0;
+            window->body->input.pointer.y = 0;
+            window->body->input.pointer.left_button = LV_INDEV_STATE_RELEASED;
+            window->body->input.pointer.right_button = LV_INDEV_STATE_RELEASED;
+            window->body->input.pointer.wheel_button = LV_INDEV_STATE_RELEASED;
+            window->body->input.pointer.wheel_diff = 0;
+            if (window->application->pointer_obj == window->body)
+            {
+                window->application->pointer_obj = NULL;
+            }
+
+            window->body->input.keyboard.key = 0;
+            window->body->input.keyboard.state = LV_INDEV_STATE_RELEASED;
+            if (window->application->keyboard_obj == window->body)
+            {
+                window->application->keyboard_obj = NULL;
+            }
+        }
+        else if (!window->closed)
+        {
+            shall_flush |= window->flush_pending;
+        }
+        window->flush_pending = false;
+    }
+
+    if (shall_flush)
+    {
+        wl_display_flush(application.display);
+        application.cursor_flush_pending = false;
+    }
+
+    wl_display_read_events(application.display);
+    wl_display_dispatch_pending(application.display);
+}
+
+static void _lv_wayland_pointer_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+    struct window *window = drv->disp->driver->user_data;
+    if (!window)
+    {
+        return;
+    }
+
+    data->point.x = window->body->input.pointer.x;
+    data->point.y = window->body->input.pointer.y;
+    data->state = window->body->input.pointer.left_button;
+}
+
+static void _lv_wayland_pointeraxis_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+    struct window *window = drv->disp->driver->user_data;
+    if (!window)
+    {
+        return;
+    }
+
+    data->state = window->body->input.pointer.wheel_button;
+    data->enc_diff = window->body->input.pointer.wheel_diff;
+
+    window->body->input.pointer.wheel_diff = 0;
+}
+
+static void _lv_wayland_keyboard_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+    struct window *window = drv->disp->driver->user_data;
+    if (!window)
+    {
+        return;
+    }
+
+    data->key = window->body->input.keyboard.key;
+    data->state = window->body->input.keyboard.state;
+}
+
+static void _lv_wayland_touch_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+    struct window *window = drv->disp->driver->user_data;
+    if (!window)
+    {
+        return;
+    }
+
+    data->point.x = window->body->input.touch.x;
+    data->point.y = window->body->input.touch.y;
+    data->state = window->body->input.touch.state;
+}
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+/**
+ * Initialize Wayland driver
+ */
+void lv_wayland_init(void)
+{
+    application.xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+    LV_ASSERT_MSG(application.xdg_runtime_dir, "cannot get XDG_RUNTIME_DIR\n");
+
+    // Create XKB context
+    application.xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    LV_ASSERT_MSG(application.xkb_context, "failed to create XKB context");
+    if (application.xkb_context == NULL)
+    {
+        return;
+    }
+
+    // Connect to Wayland display
+    application.display = wl_display_connect(NULL);
+    LV_ASSERT_MSG(application.display, "failed to connect to Wayland server");
+    if (application.display == NULL)
+    {
+        return;
+    }
+
+    /* Add registry listener and wait for registry reception */
+    application.format = 0xFFFFFFFF;
+    application.registry = wl_display_get_registry(application.display);
+    wl_registry_add_listener(application.registry, &registry_listener, &application);
+    wl_display_dispatch(application.display);
+    wl_display_roundtrip(application.display);
+
+    LV_ASSERT_MSG(application.compositor, "Wayland compositor not available");
+    if (application.compositor == NULL)
+    {
+        return;
+    }
+
+    LV_ASSERT_MSG(application.shm, "Wayland SHM not available");
+    if (application.shm == NULL)
+    {
+        return;
+    }
+
+    LV_ASSERT_MSG((application.format != 0xFFFFFFFF), "WL_SHM_FORMAT not available");
+    if (application.format == 0xFFFFFFFF)
+    {
+        return;
+    }
+
+#ifdef LV_WAYLAND_CLIENT_SIDE_DECORATIONS
+    const char * env_disable_decorations = getenv("LV_WAYLAND_DISABLE_WINDOWDECORATION");
+    application.opt_disable_decorations = ((env_disable_decorations != NULL) &&
+                                           (env_disable_decorations[0] != '0'));
+#endif
+
+    _lv_ll_init(&application.window_ll, sizeof(struct window));
+
+    application.cycle_timer = lv_timer_create(_lv_wayland_cycle, LV_WAYLAND_CYCLE_PERIOD, NULL);
+    LV_ASSERT_MSG(application.cycle_timer, "failed to create cycle timer");
+    if (!application.cycle_timer)
+    {
+        return;
+    }
+}
+
+/**
+ * De-initialize Wayland driver
+ */
+void lv_wayland_deinit(void)
+{
+    struct window *window = NULL;
+
+    _LV_LL_READ(&application.window_ll, window)
+    {
+        if (!window->closed)
+        {
+            destroy_window(window);
+        }
+    }
+
+    if (application.shm)
+    {
+        wl_shm_destroy(application.shm);
+    }
+
+#if LV_WAYLAND_XDG_SHELL
+    if (application.xdg_wm)
+    {
+        xdg_wm_base_destroy(application.xdg_wm);
+    }
+#endif
+
+#if LV_WAYLAND_WL_SHELL
+    if (application.wl_shell)
+    {
+        wl_shell_destroy(application.wl_shell);
+    }
+#endif
+
+    if (application.wl_seat)
+    {
+        wl_seat_destroy(application.wl_seat);
+    }
+
+    if (application.subcompositor)
+    {
+        wl_subcompositor_destroy(application.subcompositor);
+    }
+
+    if (application.compositor)
+    {
+        wl_compositor_destroy(application.compositor);
+    }
+
+    wl_registry_destroy(application.registry);
+    wl_display_flush(application.display);
+    wl_display_disconnect(application.display);
+
+    _lv_ll_clear(&application.window_ll);
+}
+
+/**
+ * Create wayland window
+ * @param hor_res initial horizontal window size in pixels
+ * @param ver_res initial vertical window size in pixels
+ * @param title window title
+ * @param close_cb function to be called when the window gets closed by the user (optional)
+ * @return new display backed by a Wayland window, or NULL on error
+ */
+lv_disp_t * lv_wayland_create_window(lv_coord_t hor_res, lv_coord_t ver_res, char *title,
+                                     lv_wayland_display_close_f_t close_cb)
+{
+    lv_color_t * buf1 = NULL;
+    struct window *window;
+
+    window = create_window(&application, hor_res, ver_res, title);
+    if (!window)
+    {
+        LV_LOG_ERROR("failed to create wayland window\n");
+        return NULL;
+    }
+
+    window->close_cb = close_cb;
+
+    /* Initialize draw buffer */
+    buf1 = lv_mem_alloc(hor_res * ver_res * sizeof(lv_color_t));
+    if (!buf1)
+    {
+        LV_LOG_ERROR("failed to allocate draw buffer\n");
+        destroy_window(window);
+        return NULL;
+    }
+
+    lv_disp_draw_buf_init(&window->lv_disp_draw_buf, buf1, NULL, hor_res * ver_res);
+
+    /* Initialize display driver */
+    lv_disp_drv_init(&window->lv_disp_drv);
+    window->lv_disp_drv.draw_buf = &window->lv_disp_draw_buf;
+    window->lv_disp_drv.hor_res = hor_res;
+    window->lv_disp_drv.ver_res = ver_res;
+    window->lv_disp_drv.flush_cb = _lv_wayland_flush;
+    window->lv_disp_drv.user_data = window;
+
+    /* Register display */
+    window->lv_disp = lv_disp_drv_register(&window->lv_disp_drv);
+
+    /* Register input */
+    lv_indev_drv_init(&window->lv_indev_drv_pointer);
+    window->lv_indev_drv_pointer.type = LV_INDEV_TYPE_POINTER;
+    window->lv_indev_drv_pointer.read_cb = _lv_wayland_pointer_read;
+    window->lv_indev_drv_pointer.disp = window->lv_disp;
+    window->lv_indev_pointer = lv_indev_drv_register(&window->lv_indev_drv_pointer);
+    if (!window->lv_indev_pointer)
+    {
+        LV_LOG_ERROR("failed to register pointer indev\n");
+    }
+
+    lv_indev_drv_init(&window->lv_indev_drv_pointeraxis);
+    window->lv_indev_drv_pointeraxis.type = LV_INDEV_TYPE_ENCODER;
+    window->lv_indev_drv_pointeraxis.read_cb = _lv_wayland_pointeraxis_read;
+    window->lv_indev_drv_pointeraxis.disp = window->lv_disp;
+    window->lv_indev_pointeraxis = lv_indev_drv_register(&window->lv_indev_drv_pointeraxis);
+    if (!window->lv_indev_pointeraxis)
+    {
+        LV_LOG_ERROR("failed to register pointeraxis indev\n");
+    }
+
+    lv_indev_drv_init(&window->lv_indev_drv_touch);
+    window->lv_indev_drv_touch.type = LV_INDEV_TYPE_POINTER;
+    window->lv_indev_drv_touch.read_cb = _lv_wayland_touch_read;
+    window->lv_indev_drv_touch.disp = window->lv_disp;
+    window->lv_indev_touch = lv_indev_drv_register(&window->lv_indev_drv_touch);
+    if (!window->lv_indev_touch)
+    {
+        LV_LOG_ERROR("failed to register touch indev\n");
+    }
+
+    lv_indev_drv_init(&window->lv_indev_drv_keyboard);
+    window->lv_indev_drv_keyboard.type = LV_INDEV_TYPE_KEYPAD;
+    window->lv_indev_drv_keyboard.read_cb = _lv_wayland_keyboard_read;
+    window->lv_indev_drv_keyboard.disp = window->lv_disp;
+    window->lv_indev_keyboard = lv_indev_drv_register(&window->lv_indev_drv_keyboard);
+    if (!window->lv_indev_keyboard)
+    {
+        LV_LOG_ERROR("failed to register keyboard indev\n");
+    }
+
+    return window->lv_disp;
+}
+
+/**
+ * Close wayland window
+ * @param disp LVGL display using window to be closed
+ */
+void lv_wayland_close_window(lv_disp_t * disp)
+{
+    struct window *window = disp->driver->user_data;
+    if (!window || window->closed)
+    {
+        return;
+    }
+    window->shall_close = true;
+    window->close_cb = NULL;
+}
+
+/**
+ * Get pointer input device for given LVGL display
+ * @param disp LVGL display
+ * @return input device connected to pointer events, or NULL on error
+ */
+lv_indev_t * lv_wayland_get_pointer(lv_disp_t * disp)
+{
+    struct window *window = disp->driver->user_data;
+    if (!window)
+    {
+        return NULL;
+    }
+    return window->lv_indev_pointer;
+}
+
+/**
+ * Get pointer axis input device for given LVGL display
+ * @param disp LVGL display
+ * @return input device connected to pointer axis events, or NULL on error
+ */
+lv_indev_t * lv_wayland_get_pointeraxis(lv_disp_t * disp)
+{
+    struct window *window = disp->driver->user_data;
+    if (!window)
+    {
+        return NULL;
+    }
+    return window->lv_indev_pointeraxis;
+}
+
+/**
+ * Get keyboard input device for given LVGL display
+ * @param disp LVGL display
+ * @return input device connected to keyboard, or NULL on error
+ */
+lv_indev_t * lv_wayland_get_keyboard(lv_disp_t * disp)
+{
+    struct window *window = disp->driver->user_data;
+    if (!window)
+    {
+        return NULL;
+    }
+    return window->lv_indev_keyboard;
+}
+
+/**
+ * Get touchscreen input device for given LVGL display
+ * @param disp LVGL display
+ * @return input device connected to touchscreen, or NULL on error
+ */
+lv_indev_t * lv_wayland_get_touchscreen(lv_disp_t * disp)
+{
+    struct window *window = disp->driver->user_data;
+    if (!window)
+    {
+        return NULL;
+    }
+    return window->lv_indev_touch;
+}
+
+#endif // USE_WAYLAND

--- a/wayland/wayland.c
+++ b/wayland/wayland.c
@@ -98,7 +98,7 @@ struct application {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void * wayland_dispatch_handler(void *data);
+static void * dispatch_handler(void *data);
 static void handle_global(void *data, struct wl_registry *registry, uint32_t name,
                           const char *interface, uint32_t version);
 static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name);
@@ -209,7 +209,7 @@ static struct application application;
 /**
  * Initialize Wayland driver
  */
-void wayland_init(void)
+void lv_wayland_init(void)
 {
     struct wl_shm_pool *pool;
 
@@ -326,13 +326,13 @@ void wayland_init(void)
     wl_shell_surface_set_title(application.shell_surface, WAYLAND_SURF_TITLE);
 
     pthread_mutex_init(&application.mutex, NULL);
-    pthread_create(&application.thread, NULL, wayland_dispatch_handler, &application);
+    pthread_create(&application.thread, NULL, dispatch_handler, &application);
 }
 
 /**
  * De-initialize Wayland driver
  */
-void wayland_deinit(void)
+void lv_wayland_deinit(void)
 {
     pthread_cancel(application.thread);
 
@@ -367,7 +367,7 @@ void wayland_deinit(void)
  * @param area an area where to copy `color_p`
  * @param color_p an array of pixel to copy to the `area` part of the screen
  */
-void wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p)
+void lv_wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p)
 {
     lv_coord_t hres = (disp_drv->rotated == 0) ? (disp_drv->hor_res) : (disp_drv->ver_res);
     lv_coord_t vres = (disp_drv->rotated == 0) ? (disp_drv->ver_res) : (disp_drv->hor_res);
@@ -417,7 +417,7 @@ void wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t 
  * @param drv pointer to driver where this function belongs
  * @param data where to store input data
  */
-void wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
+void lv_wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 {
     (void) drv; /* Unused */
 
@@ -435,7 +435,7 @@ void wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
  * @param drv pointer to driver where this function belongs
  * @param data where to store input data
  */
-void wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
+void lv_wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 {
     (void) drv; /* Unused */
 
@@ -454,7 +454,7 @@ void wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
  * @param drv pointer to driver where this function belongs
  * @param data where to store input data
  */
-void wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
+void lv_wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 {
     (void) drv; /* Unused */
 
@@ -471,7 +471,7 @@ void wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
  * @param drv pointer to driver where this function belongs
  * @param data where to store input data
  */
-void wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
+void lv_wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 {
     (void) drv; /* Unused */
 
@@ -487,7 +487,7 @@ void wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-static void * wayland_dispatch_handler(void *data)
+static void * dispatch_handler(void *data)
 {
     struct application *app = data;
 

--- a/wayland/wayland.h
+++ b/wayland/wayland.h
@@ -41,13 +41,13 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-void wayland_init(void);
-void wayland_deinit(void);
-void wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p);
-void wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
-void wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
-void wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
-void wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
+void lv_wayland_init(void);
+void lv_wayland_deinit(void);
+void lv_wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p);
+void lv_wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
+void lv_wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
+void lv_wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
+void lv_wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 
 /**********************
  *      MACROS

--- a/wayland/wayland.h
+++ b/wayland/wayland.h
@@ -42,17 +42,20 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+typedef bool (*lv_wayland_display_close_f_t)(lv_disp_t * disp);
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 void lv_wayland_init(void);
 void lv_wayland_deinit(void);
-void lv_wayland_cycle(void);
-void lv_wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p);
-void lv_wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
-void lv_wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
-void lv_wayland_keyboard_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
-void lv_wayland_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
+lv_disp_t * lv_wayland_create_window(lv_coord_t hor_res, lv_coord_t ver_res, char *title,
+                                     lv_wayland_display_close_f_t close_cb);
+void lv_wayland_close_window(lv_disp_t * disp);
+lv_indev_t * lv_wayland_get_pointer(lv_disp_t * disp);
+lv_indev_t * lv_wayland_get_pointeraxis(lv_disp_t * disp);
+lv_indev_t * lv_wayland_get_keyboard(lv_disp_t * disp);
+lv_indev_t * lv_wayland_get_touchscreen(lv_disp_t * disp);
 
 /**********************
  *      MACROS

--- a/wayland/wayland.h
+++ b/wayland/wayland.h
@@ -29,6 +29,10 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if LV_USE_USER_DATA == 0
+#error "Support for user data is required by wayland driver. Set LV_USE_USER_DATA to 1 in lv_conf.h"
+#endif
+
 
 /*********************
  *      DEFINES
@@ -43,6 +47,7 @@ extern "C" {
  **********************/
 void lv_wayland_init(void);
 void lv_wayland_deinit(void);
+void lv_wayland_cycle(void);
 void lv_wayland_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p);
 void lv_wayland_pointer_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 void lv_wayland_pointeraxis_read(lv_indev_drv_t * drv, lv_indev_data_t * data);


### PR DESCRIPTION
Hello,

this pull request enhances current Wayland support by adding the following features:

- support for multi-window applications
- basic client-side window decorations
- support for _xdg-shell_ and _ivi-application_ protocols

> **NOTE**: _xdg-shell_ and _ivi-application_ are not core protocols and thus require some additional source code to be supported; typically, Wayland protocols are distributed as XML files and .c/.h files are generated by the `wayland-scanner` utility at build time. This pull request also contains such auto-generation, but an additional (manual) step is required at build time. Details are reported inside the README.

Since the changes requires a break in API compatibility (that is, periodic call to a cycle function is required), this pull request also changes the names for current functions, in order to stress the existence of the breakage.

API breakage has two reasons:

- efficient multi-window support requires `wl_display_flush` to be called once per LVGL rendering and not once per window - thus the need to call periodically (ideally after `lv_timer_handler()`, as reported in the README) `lv_wayland_cycle()`
- pthread-based event dispatching does not match really well with the rest of LVGL infrastructure (I know, my fault during first implementation)

About **client-side window decorations**: they are very basic, just a simple gray bar on top with close and (only for XDG shell) minimize buttons. Even when enabled at compile time, decorations can be disabled at runtime setting as environment variable `LV_WAYLAND_DISABLE_WINDOWDECORATION=1`. Resizing and maximization are not supported, since there is no way to notify LVGL that window size is changed (correct me on this point if I'm wrong).

Support for **IVI shell** (that is, the _ivi-application_ prototcol) has only been smoke-tested at the moment.

Since changes are quite invasive, I marked this as RFC - in particular, I'd like to hear opinions about the code auto-generation for extra protocols.

