### PR TITLE
build add install rule to CMakeList.txt (#169)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(lv_drivers
 file(GLOB_RECURSE SOURCES ./*.c)
 add_library(lv_drivers STATIC ${SOURCES})
 
-option(install "Enable install to system" OFF)
-if(install)
 include_directories(${CMAKE_SOURCE_DIR})
 
 if("${LIB_INSTALL_DIR}" STREQUAL "")
@@ -41,4 +39,3 @@ install(TARGETS ${CMAKE_PROJECT_NAME}
   ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
   PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}"
 )
-endif(install)


### PR DESCRIPTION
* build: Add install rule

This can help to install lvgl on systems,
for clients applications.

Relate-to: https://github.com/lvgl/lvgl/issues/2534
Forwarded: https://github.com/lvgl/lv_drivers/pull/169
Signed-off-by: Philippe Coval <philippe.coval@astrolabe.coop>

* build: Make install rules optional

Forwarded: https://github.com/lvgl/lv_drivers/pull/169
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>