### PR TITLE
CMakeLists.txt: Don't use ${CMAKE_PROJECT_NAME} to enable including

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if("${LIB_INSTALL_DIR}" STREQUAL "")
 endif()
 
 if("${INC_INSTALL_DIR}" STREQUAL "")
-  set(INC_INSTALL_DIR "include/lvgl/${CMAKE_PROJECT_NAME}")
+  set(INC_INSTALL_DIR "include/lvgl/lv_drivers")
 endif()
 
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/"
@@ -29,13 +29,13 @@ file(GLOB LV_DRIVERS_PUBLIC_HEADERS
   "${CMAKE_SOURCE_DIR}/lv_drv_conf.h"
   )
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
-  OUTPUT_NAME ${CMAKE_PROJECT_NAME}
+set_target_properties(lv_drivers PROPERTIES
+  OUTPUT_NAME lv_drivers
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
   PUBLIC_HEADER "${LV_DRIVERS_PUBLIC_HEADERS}"
 )
 
-install(TARGETS ${CMAKE_PROJECT_NAME}
+install(TARGETS lv_drivers
   ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
   PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}"
 )


### PR DESCRIPTION
Replace use of ${CMAKE_PROJECT_NAME} with literal project name since this variable will return the upper-level CMake project name if this project is included by it.