### PR TITLE
fix(CMake) add includes and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,15 @@
-project(lv_drivers
-  HOMEPAGE_URL https://github.com/lvgl/lv_drivers/
-  )
+cmake_minimum_required(VERSION 3.12.4)
+
+project(lv_drivers HOMEPAGE_URL https://github.com/lvgl/lv_drivers/)
 
 file(GLOB_RECURSE SOURCES ./*.c)
 add_library(lv_drivers STATIC ${SOURCES})
+add_library(lvgl_drivers ALIAS lv_drivers)
+add_library(lvgl::drivers ALIAS lv_drivers)
 
-include_directories(${CMAKE_SOURCE_DIR})
+target_include_directories(lv_drivers SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(lv_drivers PUBLIC lvgl)
 
 if("${LIB_INSTALL_DIR}" STREQUAL "")
   set(LIB_INSTALL_DIR "lib")
@@ -15,27 +19,25 @@ if("${INC_INSTALL_DIR}" STREQUAL "")
   set(INC_INSTALL_DIR "include/lvgl/lv_drivers")
 endif()
 
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/"
+install(
+  DIRECTORY "${CMAKE_SOURCE_DIR}/"
   DESTINATION "${CMAKE_INSTALL_PREFIX}/${INC_INSTALL_DIR}/"
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN ".git*" EXCLUDE
   PATTERN "CMakeFiles" EXCLUDE
   PATTERN "docs" EXCLUDE
-  PATTERN "lib" EXCLUDE
-  )
+  PATTERN "lib" EXCLUDE)
 
-file(GLOB LV_DRIVERS_PUBLIC_HEADERS
-  "${CMAKE_SOURCE_DIR}/lv_drv_conf.h"
-  )
+file(GLOB LV_DRIVERS_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/lv_drv_conf.h")
 
-set_target_properties(lv_drivers PROPERTIES
-  OUTPUT_NAME lv_drivers
-  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-  PUBLIC_HEADER "${LV_DRIVERS_PUBLIC_HEADERS}"
-)
+set_target_properties(
+  lv_drivers
+  PROPERTIES OUTPUT_NAME lv_drivers
+             ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+             PUBLIC_HEADER "${LV_DRIVERS_PUBLIC_HEADERS}")
 
-install(TARGETS lv_drivers
+install(
+  TARGETS lv_drivers
   ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
-  PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}"
-)
+  PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}")


### PR DESCRIPTION
- Changed include_directories (bad practice) to target_include_directories
- Added dependencies
  - lv_drivers depends on lvgl
- Namespaced target aliases
  - lvgl::drivers
- Applied cmake-format for a consistent style

This PR is also part of [#2753](https://github.com/lvgl/lvgl/pull/2753)