### PR TITLE
fix(sdl) Default macro defs for SDL and XKB drivers

### DIFF
--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -463,11 +463,11 @@
 /*-------------------------------------------------
  * Full keyboard support for evdev and libinput interface
  *------------------------------------------------*/
-#if USE_LIBINPUT || USE_BSD_LIBINPUT || USE_EVDEV || USE_BSD_EVDEV
 #  ifndef USE_XKB
 #    define USE_XKB           0
 #  endif
 
+#if USE_LIBINPUT || USE_BSD_LIBINPUT || USE_EVDEV || USE_BSD_EVDEV
 #  if USE_XKB
 #    define XKB_KEY_MAP       { .rules = NULL, \
                                 .model = "pc101", \

--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -41,13 +41,11 @@
 # define SDL_INCLUDE_PATH       MONITOR_SDL_INCLUDE_PATH
 # define SDL_VIRTUAL_MACHINE    MONITOR_VIRTUAL_MACHINE
 # define SDL_DUAL_DISPLAY       MONITOR_DUAL
+#endif
 
 #ifndef SDL_FULLSCREEN
-#define SDL_FULLSCREEN        0
+# define SDL_FULLSCREEN        0
 #endif
-
-#endif
-
 
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
Code referencing SDL_FULLSCREEN and USE_XKB needs these macros defined unconditionally
as it doesn't check their presence with `#if defined`.