### PR TITLE
Refactor(evdev) removed duplicate code from init function

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -38,7 +38,7 @@ int map(int x, int in_min, int in_max, int out_min, int out_max);
 /**********************
  *  STATIC VARIABLES
  **********************/
-int evdev_fd;
+int evdev_fd = -1;
 int evdev_root_x;
 int evdev_root_y;
 int evdev_button;
@@ -58,26 +58,9 @@ int evdev_key_val;
  */
 void evdev_init(void)
 {
-#if USE_BSD_EVDEV
-    evdev_fd = open(EVDEV_NAME, O_RDWR | O_NOCTTY);
-#else
-    evdev_fd = open(EVDEV_NAME, O_RDWR | O_NOCTTY | O_NDELAY);
-#endif
-    if(evdev_fd == -1) {
-        perror("unable open evdev interface:");
+    if (!evdev_set_file(EVDEV_NAME)) {
         return;
     }
-
-#if USE_BSD_EVDEV
-    fcntl(evdev_fd, F_SETFL, O_NONBLOCK);
-#else
-    fcntl(evdev_fd, F_SETFL, O_ASYNC | O_NONBLOCK);
-#endif
-
-    evdev_root_x = 0;
-    evdev_root_y = 0;
-    evdev_key_val = 0;
-    evdev_button = LV_INDEV_STATE_REL;
 
 #if USE_XKB
     xkb_init();


### PR DESCRIPTION
Two almost identical functions were combined.

Small side effect is a bug fix for a perhaps never occurring use case; when evdev_set_file was being called without evdev_init, then this was closing a random device.