### PR TITLE
fix(wayland): A few Wayland driver fixes.

### DIFF
--- a/wayland/wayland.h
+++ b/wayland/wayland.h
@@ -54,6 +54,7 @@ lv_disp_t * lv_wayland_create_window(lv_coord_t hor_res, lv_coord_t ver_res, cha
                                      lv_wayland_display_close_f_t close_cb);
 void lv_wayland_close_window(lv_disp_t * disp);
 bool lv_wayland_window_is_open(lv_disp_t * disp);
+bool lv_wayland_window_is_flush_pending(lv_disp_t * disp);
 void lv_wayland_window_set_fullscreen(lv_disp_t * disp, bool fullscreen);
 lv_indev_t * lv_wayland_get_pointer(lv_disp_t * disp);
 lv_indev_t * lv_wayland_get_pointeraxis(lv_disp_t * disp);


### PR DESCRIPTION
Add a missing Wayland surface flush call (on resize), stub out a function to determine if all data was flushed (or if another attempt is necessary once the communication pipe isn't full), and finally fix some formatting (to match file convention) from a previous commit.