### PR TITLE
sdl_common: Add #if USE_SDL || USE_SDL_GPU (#211)

### DIFF
--- a/sdl/sdl_common.c
+++ b/sdl/sdl_common.c
@@ -4,6 +4,7 @@
 
 #include "sdl_common.h"
 
+#if USE_SDL || USE_SDL_GPU
 /*********************
  *      DEFINES
  *********************/
@@ -262,4 +263,4 @@ uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key)
     }
 }
 
-
+#endif  /* USE_SDL || USD_SDL_GPU */

--- a/sdl/sdl_common.h
+++ b/sdl/sdl_common.h
@@ -27,6 +27,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if USE_SDL || USE_SDL_GPU
+
 #ifndef SDL_INCLUDE_PATH
 #define SDL_INCLUDE_PATH MONITOR_SDL_INCLUDE_PATH
 #endif
@@ -93,6 +95,7 @@ void keyboard_handler(SDL_Event * event);
 /**********************
  *      MACROS
  **********************/
+#endif /* USE_SDL || USE_SDL_GPU */
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
This fixes #include SDL_INCLUDE_PATH when SDL_INCLUDE_PATH
is not set.

Change-Id: Iaf2cd2b3d6b1dfffc97d1efcc25c645e7cc188a7