### PR TITLE
Make it possible to query fbdev dpi

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -33,6 +33,10 @@
 #define FBDEV_PATH  "/dev/fb0"
 #endif
 
+#ifndef DIV_ROUND_UP
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -248,12 +252,15 @@ void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color
     lv_disp_flush_ready(drv);
 }
 
-void fbdev_get_sizes(uint32_t *width, uint32_t *height) {
+void fbdev_get_sizes(uint32_t *width, uint32_t *height, uint32_t *dpi) {
     if (width)
         *width = vinfo.xres;
 
     if (height)
         *height = vinfo.yres;
+
+    if (dpi && vinfo.height)
+        *dpi = DIV_ROUND_UP(vinfo.xres * 254, vinfo.width * 10);
 }
 
 void fbdev_set_offset(uint32_t xoffset, uint32_t yoffset) {

--- a/display/fbdev.h
+++ b/display/fbdev.h
@@ -43,7 +43,7 @@ extern "C" {
 void fbdev_init(void);
 void fbdev_exit(void);
 void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
-void fbdev_get_sizes(uint32_t *width, uint32_t *height);
+void fbdev_get_sizes(uint32_t *width, uint32_t *height, uint32_t *dpi);
 /**
  * Set the X and Y offset in the variable framebuffer info.
  * @param xoffset horizontal offset


### PR DESCRIPTION
This computes the display's DPI from the variable fbdev info which makes this method analogous to `drm_get_sizes`.