### PR TITLE
fix: hide the SDL2 include from public LVGL functions

### DIFF
--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -47,6 +47,7 @@
 # define SDL_FULLSCREEN        0
 #endif
 
+#include "sdl_common_internal.h"
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/sdl/sdl_common.c
+++ b/sdl/sdl_common.c
@@ -5,6 +5,8 @@
 #include "sdl_common.h"
 
 #if USE_SDL || USE_SDL_GPU
+#include "sdl_common_internal.h"
+
 /*********************
  *      DEFINES
  *********************/

--- a/sdl/sdl_common.h
+++ b/sdl/sdl_common.h
@@ -32,7 +32,6 @@ extern "C" {
 #ifndef SDL_INCLUDE_PATH
 #define SDL_INCLUDE_PATH MONITOR_SDL_INCLUDE_PATH
 #endif
-#include SDL_INCLUDE_PATH
 
 #ifndef SDL_ZOOM
 #define SDL_ZOOM MONITOR_ZOOM
@@ -85,16 +84,6 @@ void sdl_mousewheel_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
  */
 void sdl_keyboard_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
 
-int quit_filter(void * userdata, SDL_Event * event);
-
-void mouse_handler(SDL_Event * event);
-void mousewheel_handler(SDL_Event * event);
-uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key);
-void keyboard_handler(SDL_Event * event);
-
-/**********************
- *      MACROS
- **********************/
 #endif /* USE_SDL || USE_SDL_GPU */
 
 #ifdef __cplusplus

--- a/sdl/sdl_common_internal.h
+++ b/sdl/sdl_common_internal.h
@@ -1,0 +1,39 @@
+/**
+ * @file sdl_common_internal.h
+ * Provides SDL related functions which are only used internal.
+ *
+ */
+
+#ifndef SDL_COMMON_INTERNAL_H
+#define SDL_COMMON_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "sdl_common.h"
+
+#if USE_SDL || USE_SDL_GPU
+
+#include SDL_INCLUDE_PATH
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+int quit_filter(void * userdata, SDL_Event * event);
+
+void mouse_handler(SDL_Event * event);
+void mousewheel_handler(SDL_Event * event);
+uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key);
+void keyboard_handler(SDL_Event * event);
+
+#endif /* USE_SDL || USE_SDL_GPU */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SDL_COMMON_INTERNAL_H */

--- a/sdl/sdl_gpu.c
+++ b/sdl/sdl_gpu.c
@@ -29,6 +29,7 @@
 # error "Cannot enable both MONITOR and SDL at the same time. "
 #endif
 
+#include "sdl_common_internal.h"
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>


### PR DESCRIPTION
With this MR, the required internal functions between `sdl.h` and `sdl_gpu.h` are put into a separate header: `sdl_common_internal.h`.

### Why is this needed?

Since this commit: https://github.com/lvgl/lv_drivers/commit/462d9cdeb83df9838f3f02e6f156fc37599c9add the `SDL2/SDL.h` include is visible to other translation units from "public" LVGL headers.

Since this commit: https://github.com/lvgl/lv_drivers/commit/2a872a6912ca0dfcc7d8e243a5399d8f8c71844c `SDL2/SDL.h`  is only included, if SDL is actually used.

**Remaining problem:**
You still include the heavy `SDL2/SDL.h` from "public" LVGL headers into other translation units of the user. This wasn't the case before, and isn't the case for other display drivers (e.g. wayland, gtk, win32dr).

This can lead to other problems like one I faced today with our static code analyzer tool (clang-tidy), who tries to parse the included `<SDL2/SDL.h>` header while using GCC 11.

```
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/adxintrin.h:36:10: error: use of undeclared identifier '__builtin_ia32_sbb_u32'; did you mean '__builtin_ia32_subborrow_u32'? [clang-diagnostic-error]
  return __builtin_ia32_sbb_u32 (__CF, __X, __Y, __P);
         ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/adxintrin.h:36:10: note: '__builtin_ia32_subborrow_u32' declared here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/adxintrin.h:61:10: error: use of undeclared identifier '__builtin_ia32_sbb_u64'; did you mean '__builtin_ia32_subborrow_u64'? [clang-diagnostic-error]
  return __builtin_ia32_sbb_u64 (__CF, __X, __Y, __P);
         ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/adxintrin.h:61:10: note: '__builtin_ia32_subborrow_u64' declared here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/cetintrin.h:42:33: error: too few arguments to function call, expected 1, have 0 [clang-diagnostic-error]
  return __builtin_ia32_rdsspq ();
         ~~~~~~~~~~~~~~~~~~~~~  ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/hresetintrin.h:41:3: error: use of undeclared identifier '__builtin_ia32_hreset' [clang-diagnostic-error]
  __builtin_ia32_hreset (__EAX);
  ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/ia32intrin.h:41:10: error: use of undeclared identifier '__builtin_ia32_bsrsi' [clang-diagnostic-error]
  return __builtin_ia32_bsrsi (__X);
         ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/ia32intrin.h:112:1: error: definition of builtin function '__rdtsc' [clang-diagnostic-error]
__rdtsc (void)
^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/ia32intrin.h:134:10: error: use of undeclared identifier '__builtin_ia32_rolqi'; did you mean '__builtin_ia32_korqi'? [clang-diagnostic-error]
  return __builtin_ia32_rolqi (__X, __C);
         ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/ia32intrin.h:41:10: note: '__builtin_ia32_korqi' declared here
  return __builtin_ia32_bsrsi (__X);
         ^
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/ia32intrin.h:142:10: error: use of undeclared identifier '__builtin_ia32_rolhi'; did you mean '__builtin_ia32_korhi'? [clang-diagnostic-error]
  return __builtin_ia32_rolhi (__X, __C);
         ^
```