### PR TITLE
chore(sdl): fix warning

### DIFF
--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -9,7 +9,7 @@
 #include "sdl.h"
 #if USE_MONITOR || USE_SDL
 
-#if LV_USE_GPU_SDL
+#if defined(LV_USE_GPU_SDL) && LV_USE_GPU_SDL
 # error "LV_USE_GPU_SDL must not be enabled"
 #endif
 
@@ -96,17 +96,6 @@ monitor_t monitor;
 #if SDL_DUAL_DISPLAY
 monitor_t monitor2;
 #endif
-
-static volatile bool sdl_inited = false;
-
-static bool left_button_down = false;
-static int16_t last_x = 0;
-static int16_t last_y = 0;
-
-static int16_t wheel_diff = 0;
-static lv_indev_state_t wheel_state = LV_INDEV_STATE_RELEASED;
-
-static char buf[KEYBOARD_BUFFER_SIZE];
 
 /**********************
  *      MACROS

--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -9,8 +9,8 @@
 #include "sdl.h"
 #if USE_MONITOR || USE_SDL
 
-#if defined(LV_USE_GPU_SDL) && LV_USE_GPU_SDL
-# error "LV_USE_GPU_SDL must not be enabled"
+#if LV_USE_DRAW_SDL 
+# error "LV_USE_DRAW_SDL must not be enabled"
 #endif
 
 #if USE_MONITOR


### PR DESCRIPTION
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:12:5: warning: "LV_USE_GPU_SDL" is not defined, evaluates to 0 [-Wundef]
   12 | #if LV_USE_GPU_SDL
      |     ^~~~~~~~~~~~~~
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:109:13: warning: ‘buf’ defined but not used [-Wunused-variable]
  109 | static char buf[KEYBOARD_BUFFER_SIZE];
      |             ^~~
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:107:25: warning: ‘wheel_state’ defined but not used [-Wunused-variable]
  107 | static lv_indev_state_t wheel_state = LV_INDEV_STATE_RELEASED;
      |                         ^~~~~~~~~~~
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:106:16: warning: ‘wheel_diff’ defined but not used [-Wunused-variable]
  106 | static int16_t wheel_diff = 0;
      |                ^~~~~~~~~~
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:104:16: warning: ‘last_y’ defined but not used [-Wunused-variable]
  104 | static int16_t last_y = 0;
      |                ^~~~~~
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:103:16: warning: ‘last_x’ defined but not used [-Wunused-variable]
  103 | static int16_t last_x = 0;
      |                ^~~~~~
./lv_sim_eclipse_sdl/lv_drivers/sdl/sdl.c:102:13: warning: ‘left_button_down’ defined but not used [-Wunused-variable]
  102 | static bool left_button_down = false;
      |             ^~~~~~~~~~~~~~~~