### PR TITLE
Make windows.h lower case since it is the correct filename

### DIFF
--- a/win32drv/win32drv.h
+++ b/win32drv/win32drv.h
@@ -20,7 +20,7 @@
 
 #if USE_WIN32DRV
 
-#include <Windows.h>
+#include <windows.h>
 
 #if _MSC_VER >= 1200
  // Disable compilation warnings.


### PR DESCRIPTION
Windows itself is case insensitve, but the correct filename of _windows.h_ is written in lower case. 

If the lv_drivers is built cross-compiled for Windows from Linux via MinGW, this leads to an error, since Linux is case sensitive.

See:
https://stackoverflow.com/questions/15466613/lowercase-windows-h-and-uppercase-windows-h-difference