### PR TITLE
fix(wayland) : buffer->busy is always true in cpu render mode

### DIFF
--- a/wayland/wayland.c
+++ b/wayland/wayland.c
@@ -122,6 +122,7 @@ struct buffer_hdl
     int size;
     struct wl_buffer *wl_buffer;
     bool busy;
+    bool buffer_feedback;
 };
 
 struct buffer_allocator
@@ -1212,6 +1213,10 @@ static const struct wl_registry_listener registry_listener = {
 static void handle_wl_buffer_release(void *data, struct wl_buffer *wl_buffer)
 {
     struct buffer_hdl *buffer_hdl = (struct buffer_hdl *)data;
+    if (!buffer_hdl->buffer_feedback)
+    {
+        buffer_hdl->buffer_feedback = true;
+    }
     buffer_hdl->busy = false;
 }
 
@@ -1925,6 +1930,11 @@ static void _lv_wayland_flush(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv
 
     const lv_coord_t hres = (disp_drv->rotated == 0) ? (disp_drv->hor_res) : (disp_drv->ver_res);
     const lv_coord_t vres = (disp_drv->rotated == 0) ? (disp_drv->ver_res) : (disp_drv->hor_res);
+
+    if (!buffer->buffer_feedback)
+    {
+        buffer->busy = false;
+    }
 
     /* If private data is not set, it means window has not been initialized */
     if (!window)


### PR DESCRIPTION
`weston` is an implementation of `wayland`. And `weston` provide three render ways:
- OpenGL : GPU
- Pixman : CPU
- Noop : CPU

> use `weston --use-pixman` to explicitly indicate render in pixman render mode.

In fact, `handle_wl_buffer_release` is only invoked in GPU render mode. Just like the comment state:
```cpp
	/**
	 * compositor releases buffer
	 *
	 * Sent when this wl_buffer is no longer used by the compositor.
	 * The client is now free to reuse or destroy this buffer and its
	 * backing storage.
	 *
	 * If a client receives a release event before the frame callback
	 * requested in the same wl_surface.commit that attaches this
	 * wl_buffer to a surface, then the client is immediately free to
	 * reuse the buffer and its backing storage, and does not need a
	 * second buffer for the next surface content update. Typically
	 * this is possible, when the compositor maintains a copy of the
	 * wl_surface contents, e.g. as a GL texture. This is an important
	 * optimization for GL(ES) compositors with wl_shm clients.
	 */
```