### PR TITLE
fix(fbdev): power display on if FBDEV_DISPLAY_POWER_ON is set

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -98,11 +98,13 @@ void fbdev_init(void)
     }
     LV_LOG_INFO("The framebuffer device was opened successfully");
 
+#if FBDEV_DISPLAY_POWER_ON
     // Make sure that the display is on.
     if (ioctl(fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
         perror("ioctl(FBIOBLANK)");
         return;
     }
+#endif /* FBDEV_DISPLAY_POWER_ON */
 
 #if USE_BSD_FBDEV
     struct fbtype fb;

--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -320,7 +320,8 @@
 #endif
 
 #if USE_FBDEV
-#  define FBDEV_PATH          "/dev/fb0"
+#  define FBDEV_PATH              "/dev/fb0"
+#  define FBDEV_DISPLAY_POWER_ON  1 /* 1 to force display power during initialization */
 #endif
 
 /*-----------------------------------------
@@ -331,7 +332,8 @@
 #endif
 
 #if USE_BSD_FBDEV
-# define FBDEV_PATH		"/dev/fb0"
+#  define FBDEV_PATH              "/dev/fb0"
+#  define FBDEV_DISPLAY_POWER_ON  1 /* 1 to force display power during initialization */
 #endif
 
 /*-----------------------------------------


### PR DESCRIPTION
On some embedded devices the framebuffer driver fails when calling `ioctl(fbfd, FBIOBLANK, FB_BLANK_UNBLANK)` to power the display on.