### PR TITLE
fix: The mouse moves outside the screen area

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -237,6 +237,11 @@ void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
     if(data->point.y >= drv->disp->driver->ver_res)
       data->point.y = drv->disp->driver->ver_res - 1;
 
+    if (evdev_root_x != data->point.x)
+        evdev_root_x = data->point.x;
+    if (evdev_root_y != data->point.y)
+        evdev_root_y = data->point.y;
+
     return ;
 }
 

--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -219,9 +219,15 @@ void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
     /*Store the collected data*/
 
 #if EVDEV_CALIBRATE
+    evdev_root_x = LV_CLAMP(EVDEV_HOR_MIN, evdev_root_x, EVDEV_HOR_MAX);
+    evdev_root_y = LV_CLAMP(EVDEV_VER_MIN, evdev_root_y, EVDEV_VER_MAX);
+
     data->point.x = map(evdev_root_x, EVDEV_HOR_MIN, EVDEV_HOR_MAX, 0, drv->disp->driver->hor_res);
     data->point.y = map(evdev_root_y, EVDEV_VER_MIN, EVDEV_VER_MAX, 0, drv->disp->driver->ver_res);
 #else
+    evdev_root_x = LV_CLAMP(0, evdev_root_x, drv->disp->driver->hor_res-1);
+    evdev_root_y = LV_CLAMP(0, evdev_root_y, drv->disp->driver->ver_res-1);
+
     data->point.x = evdev_root_x;
     data->point.y = evdev_root_y;
 #endif
@@ -236,11 +242,6 @@ void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
       data->point.x = drv->disp->driver->hor_res - 1;
     if(data->point.y >= drv->disp->driver->ver_res)
       data->point.y = drv->disp->driver->ver_res - 1;
-
-    if (evdev_root_x != data->point.x)
-        evdev_root_x = data->point.x;
-    if (evdev_root_y != data->point.y)
-        evdev_root_y = data->point.y;
 
     return ;
 }


### PR DESCRIPTION
`evdev_root_x/y` will continue to increase as the mouse moves out of the screen. If you move the mouse inside the screen, wait until `evdev_root_x/y` is less than `hor/ver_res`. This is a problem.