### PR TITLE
feature(libinput): Add function to reset driver states

### DIFF
--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -138,8 +138,8 @@ bool libinput_set_file_state(libinput_drv_state_t *state, char* dev_name)
   // citing libinput.h:libinput_path_remove_device:
   // > If no matching device exists, this function does nothing.
   if (state->libinput_device) {
-    state->libinput_device = libinput_device_unref(state->libinput_device);
     libinput_path_remove_device(state->libinput_device);
+    state->libinput_device = libinput_device_unref(state->libinput_device);
   }
 
   state->libinput_device = libinput_path_add_device(state->libinput_context, dev_name);
@@ -193,6 +193,29 @@ void libinput_init_state(libinput_drv_state_t *state, char* path)
 #if USE_XKB
   xkb_init_state(&(state->xkb_state));
 #endif
+}
+
+/**
+ * De-initialise a previously initialised driver state and free any dynamically allocated memory. Use this function if you want to
+ * reuse an existing driver state.
+ * @param state driver state to de-initialize
+ */
+void libinput_deinit_state(libinput_drv_state_t *state)
+{
+  if (state->libinput_device) {
+    libinput_path_remove_device(state->libinput_device);
+    libinput_device_unref(state->libinput_device);
+  }
+
+  if (state->libinput_context) {
+    libinput_unref(state->libinput_context);
+  }
+
+#if USE_XKB
+  xkb_deinit_state(&(state->xkb_state));
+#endif
+
+  lv_memzero(state, sizeof(libinput_drv_state_t));
 }
 
 /**

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -100,6 +100,12 @@ void libinput_init(void);
  */
 void libinput_init_state(libinput_drv_state_t *state, char* path);
 /**
+ * De-initialise a previously initialised driver state and free any dynamically allocated memory. Use this function if you want to
+ * reuse an existing driver state.
+ * @param state driver state to de-initialize
+ */
+void libinput_deinit_state(libinput_drv_state_t *state);
+/**
  * Reconfigure the device file for libinput using the default driver state. Use this function if you only want
  * to connect a single device.
  * @param dev_name input device node path (e.g. /dev/input/event0)

--- a/indev/xkb.c
+++ b/indev/xkb.c
@@ -74,6 +74,23 @@ bool xkb_init_state(xkb_drv_state_t *state) {
 }
 
 /**
+ * De-initialise a previously initialised driver state and free any dynamically allocated memory. Use this function if you want to
+ * reuse an existing driver state.
+ * @param state XKB driver state to use
+ */
+void xkb_deinit_state(xkb_drv_state_t *state) {
+  if (state->keymap) {
+    xkb_keymap_unref(state->keymap);
+    state->keymap = NULL;
+  }
+
+  if (state->state) {
+    xkb_state_unref(state->state);
+    state->state = NULL;
+  }
+}
+
+/**
  * Set a new keymap to be used for processing future key events using the default driver state. Use
  * this function if you only want to connect a single device.
  * @param names XKB rule names structure (use NULL components for default values)
@@ -95,7 +112,7 @@ bool xkb_set_keymap_state(xkb_drv_state_t *state, struct xkb_rule_names names) {
     xkb_keymap_unref(state->keymap);
     state->keymap = NULL;
   }
- 
+
   state->keymap = xkb_keymap_new_from_names(context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
   if (!state->keymap) {
     perror("could not create XKB keymap");

--- a/indev/xkb.h
+++ b/indev/xkb.h
@@ -61,6 +61,12 @@ bool xkb_init(void);
  */
 bool xkb_init_state(xkb_drv_state_t *state);
 /**
+ * De-initialise a previously initialised driver state and free any dynamically allocated memory. Use this function if you want to
+ * reuse an existing driver state.
+ * @param state XKB driver state to use
+ */
+void xkb_deinit_state(xkb_drv_state_t *state);
+/**
  * Set a new keymap to be used for processing future key events using the default driver state. Use
  * this function if you only want to connect a single device.
  * @param names XKB rule names structure (use NULL components for default values)


### PR DESCRIPTION
This adds new functions to de-initialise the libinput and XKB driver states which allows existing data structures to be reused when devices are connected or disconnected at runtime.

An example of how to use this can be found in https://gitlab.com/cherrypicker/unl0kr/-/merge_requests/15.