### PR TITLE
fix(xkb): Fix memory leak by avoiding double reference

### DIFF
--- a/indev/xkb.c
+++ b/indev/xkb.c
@@ -79,14 +79,14 @@ bool xkb_init_state(xkb_drv_state_t *state) {
  * @param state XKB driver state to use
  */
 void xkb_deinit_state(xkb_drv_state_t *state) {
-  if (state->keymap) {
-    xkb_keymap_unref(state->keymap);
-    state->keymap = NULL;
-  }
-
   if (state->state) {
     xkb_state_unref(state->state);
     state->state = NULL;
+  }
+
+  if (state->keymap) {
+    xkb_keymap_unref(state->keymap);
+    state->keymap = NULL;
   }
 }
 
@@ -119,12 +119,6 @@ bool xkb_set_keymap_state(xkb_drv_state_t *state, struct xkb_rule_names names) {
     return false;
   }
 
-  state->keymap = xkb_keymap_ref(state->keymap);
-  if (!state->keymap) {
-    perror("could not reference XKB keymap");
-    return false;
-  }
-
   if (state->state) {
     xkb_state_unref(state->state);
     state->state = NULL;
@@ -133,12 +127,6 @@ bool xkb_set_keymap_state(xkb_drv_state_t *state, struct xkb_rule_names names) {
   state->state = xkb_state_new(state->keymap);
   if (!state->state) {
     perror("could not create XKB state");
-    return false;
-  }
-
-  state->state = xkb_state_ref(state->state);
-  if (!state->state) {
-    perror("could not reference XKB state");
     return false;
   }
 


### PR DESCRIPTION
This leak was reported by Valgrind in unl0kr (see https://gitlab.com/cherrypicker/unl0kr/-/issues/43). It turns out that `xkb_keymap_new` and `xkb_state_new` return referenced instances. So the extra calls to `xkb_keymap_ref` and `xkb_state_ref` were not needed and caused the memory to not be properly cleaned up in `xkb_deinit_state`.

Apologies for introducing this bug together with the original XKB work in lv_drivers. I was mistakenly assuming this was the correct way to use the API because the libinput API worked this way.