### PR TITLE
Add a way to set SDL window title from lv_drv_conf.h

### DIFF
--- a/lv_drv_conf_template.h
+++ b/lv_drv_conf_template.h
@@ -110,6 +110,9 @@
 
 /*Open two windows to test multi display support*/
 #  define SDL_DUAL_DISPLAY            0
+
+/* Window Title  */
+#  define SDL_WINDOW_TITLE "TFT Simulator"
 #endif
 
 /*-------------------

--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -60,6 +60,9 @@
 #define KEYBOARD_BUFFER_SIZE SDL_TEXTINPUTEVENT_TEXT_SIZE
 #endif
 
+#ifndef SDL_WINDOW_TITLE
+#define SDL_WINDOW_TITLE "TFT Simulator"
+#endif
 /**********************
  *      TYPEDEFS
  **********************/

--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -334,7 +334,7 @@ static void window_create(monitor_t * m)
     flag |= SDL_WINDOW_FULLSCREEN;
 #endif
 
-    m->window = SDL_CreateWindow("TFT Simulator",
+    m->window = SDL_CreateWindow(SDL_WINDOW_TITLE,
                               SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
                               SDL_HOR_RES * SDL_ZOOM, SDL_VER_RES * SDL_ZOOM, flag);       /*last param. SDL_WINDOW_BORDERLESS to hide borders*/
 


### PR DESCRIPTION
I'm trying to use LVGL and SDL to write one cross platform GUI application, but the window title for SDL is hardcode in the sdl.c. Therefore, it would be nice to have a way to set SDL window title from lv_drv_conf.h just as other setting.