### PR TITLE
Libinput and fbdev improvements for unl0kr

### DIFF
--- a/display/fbdev.h
+++ b/display/fbdev.h
@@ -51,6 +51,11 @@ void fbdev_get_sizes(uint32_t *width, uint32_t *height, uint32_t *dpi);
  */
 void fbdev_set_offset(uint32_t xoffset, uint32_t yoffset);
 
+/**
+ * Force the display to be refreshed on every change.
+ * Expected to be used with direct_mode or full_refresh.
+ */
+void fbdev_force_refresh(bool enabled);
 
 /**********************
  *      MACROS

--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -607,6 +607,7 @@ static void read_pointer(libinput_drv_state_t *state, struct libinput_event *eve
       }
       evt->point.x = x_pointer;
       evt->point.y = y_pointer;
+      evt->pressed = state->pointer_button_down;
       break;
     }
     case LIBINPUT_EVENT_POINTER_BUTTON: {

--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -677,6 +677,19 @@ static void read_keypad(libinput_drv_state_t *state, struct libinput_event *even
       if (evt->key_val != 0) {
         /* Only record button state when actual output is produced to prevent widgets from refreshing */
         evt->pressed = (key_state == LIBINPUT_KEY_STATE_RELEASED) ? LV_INDEV_STATE_REL : LV_INDEV_STATE_PR;
+
+        // just release the key immediatly after it got pressed.
+        // but don't handle special keys where holding a key makes sense
+        if (evt->key_val != LV_KEY_BACKSPACE &&
+            evt->key_val != LV_KEY_UP &&
+            evt->key_val != LV_KEY_LEFT &&
+            evt->key_val != LV_KEY_RIGHT &&
+            evt->key_val != LV_KEY_DOWN &&
+            key_state == LIBINPUT_KEY_STATE_PRESSED) {
+          libinput_lv_event_t *release_evt = new_event(state);
+          release_evt->pressed = LV_INDEV_STATE_REL;
+          release_evt->key_val = evt->key_val;
+        }
       }
       break;
     default:

--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -565,6 +565,7 @@ static void read_pointer(libinput_drv_state_t *state, struct libinput_event *eve
         /* Append the real release event for the first finger */
         evt = new_event(state);
         evt->pressed = LV_INDEV_STATE_REL;
+        evt->point = state->slots[0].point;
 
         /* Inject the dummy press event for the second finger */
         synth_evt = new_event(state);
@@ -577,6 +578,7 @@ static void read_pointer(libinput_drv_state_t *state, struct libinput_event *eve
 
         /* Append the real release event for the second finger */
         evt->pressed = LV_INDEV_STATE_REL;
+        evt->point = state->slots[1].point;
 
         /* Inject the dummy press event for the first finger */
         libinput_lv_event_t *synth_evt = new_event(state);
@@ -584,6 +586,7 @@ static void read_pointer(libinput_drv_state_t *state, struct libinput_event *eve
         synth_evt->point = state->slots[0].point;
       } else {
         evt->pressed = LV_INDEV_STATE_REL;
+        evt->point = state->slots[slot].point;
       }
 
       state->slots[slot].pressed = evt->pressed;

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -66,6 +66,7 @@ typedef struct {
   /* The points array is implemented as a circular LIFO queue */
   libinput_lv_event_t points[MAX_EVENTS]; /* Event buffer */
   libinput_lv_event_t slots[2]; /* Realtime state of up to 2 fingers to handle multitouch */
+  bool pointer_button_down;
   int doing_mtouch_dummy_event;
   int start; /* Index of start of event queue */
   int end; /* Index of end of queue*/

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -55,6 +55,7 @@ typedef struct {
   int key_val;
   lv_point_t point;
   bool is_relative;
+  int slot : 4;
 } libinput_lv_event_t;
 
 #define MAX_EVENTS 32
@@ -64,6 +65,8 @@ typedef struct {
 
   /* The points array is implemented as a circular LIFO queue */
   libinput_lv_event_t points[MAX_EVENTS]; /* Event buffer */
+  libinput_lv_event_t slots[2]; /* Realtime state of up to 2 fingers to handle multitouch */
+  int doing_mtouch_dummy_event;
   int start; /* Index of start of event queue */
   int end; /* Index of end of queue*/
   libinput_lv_event_t last_event; /* Report when no new events

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -54,6 +54,7 @@ typedef struct {
   lv_indev_state_t pressed;
   int key_val;
   lv_point_t point;
+  bool is_relative;
 } libinput_lv_event_t;
 
 #define MAX_EVENTS 32

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -54,7 +54,6 @@ typedef struct {
   lv_indev_state_t pressed;
   int key_val;
   lv_point_t point;
-  int slot : 4;
 } libinput_lv_event_t;
 
 #define MAX_EVENTS 32
@@ -70,7 +69,6 @@ typedef struct {
   lv_point_t pointer_position;
   bool pointer_button_down;
 
-  int doing_mtouch_dummy_event;
   int start; /* Index of start of event queue */
   int end; /* Index of end of queue*/
   libinput_lv_event_t last_event; /* Report when no new events

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -54,7 +54,6 @@ typedef struct {
   lv_indev_state_t pressed;
   int key_val;
   lv_point_t point;
-  bool is_relative;
   int slot : 4;
 } libinput_lv_event_t;
 
@@ -66,7 +65,11 @@ typedef struct {
   /* The points array is implemented as a circular LIFO queue */
   libinput_lv_event_t points[MAX_EVENTS]; /* Event buffer */
   libinput_lv_event_t slots[2]; /* Realtime state of up to 2 fingers to handle multitouch */
+
+  /* Pointer devices work a bit differently in libinput which requires us to store their last known state */
+  lv_point_t pointer_position;
   bool pointer_button_down;
+
   int doing_mtouch_dummy_event;
   int start; /* Index of start of event queue */
   int end; /* Index of end of queue*/

--- a/indev/libinput_drv.h
+++ b/indev/libinput_drv.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 #include <poll.h>
+#include <pthread.h>
 
 #if USE_XKB
 #include "xkb.h"
@@ -50,12 +51,26 @@ typedef enum {
 } libinput_capability;
 
 typedef struct {
+  lv_indev_state_t pressed;
+  int key_val;
+  lv_point_t point;
+} libinput_lv_event_t;
+
+#define MAX_EVENTS 32
+typedef struct {
   int fd;
   struct pollfd fds[1];
 
-  int button;
-  int key_val;
-  lv_point_t most_recent_touch_point;
+  /* The points array is implemented as a circular LIFO queue */
+  libinput_lv_event_t points[MAX_EVENTS]; /* Event buffer */
+  int start; /* Index of start of event queue */
+  int end; /* Index of end of queue*/
+  libinput_lv_event_t last_event; /* Report when no new events
+                                   * to keep indev state consistent
+                                   */
+  bool deinit; /* Tell worker thread to quit */
+  pthread_mutex_t event_lock;
+  pthread_t worker_thread;
 
   struct libinput *libinput_context;
   struct libinput_device *libinput_device;


### PR DESCRIPTION
Add a framebuffer quirk to force the display to refresh after every draw, this is needed for some quirky panels and DRM/fbdev emulation setups. It requires that the display buffer is set to the same size as the whole framebuffer so that the entire display can be flushed at once if needed, otherwise there is tearing.

Also use pthreads and a small circular queue to stop the libinput driver from dropping inputs. The LVGL tickrate can't always keep up and this ensures that inputs aren't dropped.

The keypad support needs to be tested.

Cc: @Johennes 