### PR TITLE
drm: Default to XRGB8888 framebuffer

### DIFF
--- a/display/drm.c
+++ b/display/drm.c
@@ -759,7 +759,7 @@ void drm_flush(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv_color_t *color
 }
 
 #if LV_COLOR_DEPTH == 32
-#define DRM_FOURCC DRM_FORMAT_ARGB8888
+#define DRM_FOURCC DRM_FORMAT_XRGB8888
 #elif LV_COLOR_DEPTH == 16
 #define DRM_FOURCC DRM_FORMAT_RGB565
 #else


### PR DESCRIPTION
The ARGB8888 framebuffer format for base canvas makes little sense as the base canvas is unlikely to be transparent and require alpha. Use XRGB8888 framebuffer format which is more widely supported by DRM drivers as base plane pixel format.

This makes e.g. i.MX8M Nano work by default.