### PR TITLE
Fix crash in sdl.c during startup in certain conditions

### DIFF
--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -368,7 +368,7 @@ static void window_update(monitor_t * m)
 #endif
     SDL_RenderClear(m->renderer);
     lv_disp_t * d = _lv_refr_get_disp_refreshing();
-    if(d->driver->screen_transp) {
+    if(d && d->driver->screen_transp) {
         SDL_SetRenderDrawColor(m->renderer, 0xff, 0, 0, 0xff);
         SDL_Rect r;
         r.x = 0; r.y = 0; r.w = SDL_HOR_RES; r.h = SDL_VER_RES;


### PR DESCRIPTION
I have encountered that the pointer is NULL when I have a lot of screens and objects during startup. If I remove objects I can get it working again which is very strange. So it seams that it is dependent on how many lvObj that has beed created. Adding a null check seams to work.