### PR TITLE
fix(build): Update xpt2046_read to match signature required by...

### DIFF
--- a/indev/XPT2046.c
+++ b/indev/XPT2046.c
@@ -55,9 +55,9 @@ void xpt2046_init(void)
 /**
  * Get the current position and state of the touchpad
  * @param data store the read data here
- * @return false: because no ore data to be read
+ * @return void
  */
-bool xpt2046_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data)
+void xpt2046_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data)
 {
     static int16_t last_x = 0;
     static int16_t last_y = 0;
@@ -105,7 +105,7 @@ bool xpt2046_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data)
     data->point.x = x;
     data->point.y = y;
 
-    return false;
+    data->continue_reading = false;    /* No more data to be read */
 }
 
 /**********************

--- a/indev/XPT2046.h
+++ b/indev/XPT2046.h
@@ -41,7 +41,7 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 void xpt2046_init(void);
-bool xpt2046_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
+void xpt2046_read(lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
...`lv_indev_drv_t`'s read callback.

The indev read callback previously returned `bool` to indicate whether it should be called again. Per the changelog, this was modified to return this indicator in the `lv_indev_data_t` struct's `continue_reading` member. This change updates the `xpt2046_read` function to be compatible with this new calling convention.

BREAKING CHANGE

Fixes #289.