### PR TITLE
fix(drm): backport drm driver fixes from lvgl 9

### DIFF
--- a/display/drm.h
+++ b/display/drm.h
@@ -44,7 +44,6 @@ void drm_init(void);
 void drm_get_sizes(lv_coord_t *width, lv_coord_t *height, uint32_t *dpi);
 void drm_exit(void);
 void drm_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
-void drm_wait_vsync(lv_disp_drv_t * drv);
 
 
 /**********************


### PR DESCRIPTION
Applied relevant fixes from https://github.com/lvgl/lvgl/pull/4621, so that they can be used with lvgl 8.x.

Edit: Putting on hold to check some details wrt. `drm_wait_vsync()`.