### PR TITLE
fix(drm): backport drm driver fixes from lvgl 9

### DIFF
--- a/display/drm.h
+++ b/display/drm.h
@@ -40,12 +40,13 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-int drm_init(void);
-void drm_get_sizes(lv_coord_t *width, lv_coord_t *height, uint32_t *dpi);
+
+int drm_init(void); /*Deprecated: Use drm_disp_drv_init instead*/
+int drm_disp_drv_init(lv_disp_drv_t * disp_drv);
+void drm_get_sizes(lv_coord_t * width, lv_coord_t * height, uint32_t * dpi);
 void drm_exit(void);
 void drm_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
-void drm_wait_vsync(lv_disp_drv_t * drv);
-
+void drm_wait_vsync(lv_disp_drv_t * drv); /*Deprecated*/
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Applied fixes/improvements from:

 - https://github.com/lvgl/lvgl/pull/4621
 - https://github.com/lvgl/lvgl/pull/4659
 - https://github.com/lvgl/lvgl/pull/4661

Remains backwards compatible, but replacing `drm_init()` with `drm_disp_drv_init()` is required for optimal performance.