### PR TITLE
perf(drm): use wait_cb for direct double-buffered rendering

### DIFF
--- a/display/drm.h
+++ b/display/drm.h
@@ -46,7 +46,7 @@ int drm_disp_drv_init(lv_disp_drv_t * disp_drv);
 void drm_get_sizes(lv_coord_t * width, lv_coord_t * height, uint32_t * dpi);
 void drm_exit(void);
 void drm_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p);
-void drm_wait_vsync(lv_disp_drv_t * drv); /*Deprecated*/
+void drm_wait_vsync(lv_disp_drv_t * drv);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Follow-up patch mentioned in #298. Slightly improves benchmark performance, as expected.