### PR TITLE
Add pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(lv_drivers SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 find_package(PkgConfig)
 pkg_check_modules(PKG_WAYLAND wayland-client wayland-cursor wayland-protocols xkbcommon)
+pkg_check_modules(PKG_LVGL lvgl)
 target_link_libraries(lv_drivers PUBLIC lvgl ${PKG_WAYLAND_LIBRARIES})
 
 if("${LIB_INSTALL_DIR}" STREQUAL "")
@@ -38,7 +39,16 @@ install(
   PATTERN ".git*" EXCLUDE
   PATTERN "CMakeFiles" EXCLUDE
   PATTERN "docs" EXCLUDE
-  PATTERN "lib" EXCLUDE)
+  PATTERN "lib" EXCLUDE
+  PATTERN "*.pc.in" EXCLUDE)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${PKG_LVGL_CFLAGS}")
+
+configure_file("${CMAKE_SOURCE_DIR}/lv-drivers.pc.in" lv-drivers.pc @ONLY)
+
+install(
+  FILES "${CMAKE_BINARY_DIR}/lv-drivers.pc"
+  DESTINATION "${LIB_INSTALL_DIR}/pkgconfig/")
 
 file(GLOB LV_DRIVERS_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/lv_drv_conf.h")
 

--- a/lv-drivers.pc.in
+++ b/lv-drivers.pc.in
@@ -1,0 +1,11 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+includedir="${prefix}/@INC_INSTALL_DIR@"
+libdir=${prefix}/lib
+
+Name: lv-drivers
+Description: Display controller and touchpad driver that can be directly used with LVGL
+URL: https://lvgl.io/
+Version: 9.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -llv_drivers
+Requires: lvgl


### PR DESCRIPTION
Working with lv-drivers headers is a bit problematic. This is because the headers have not the same path when they are build compared to when they are used from another program. This will make it possible to ask `pkg-config --lib` to get required libs and `pkg-config --cflags` to get required cflags.

