### PR TITLE
Filter the sdl driver mouse events to the correct monitor

### DIFF
--- a/sdl/sdl.c
+++ b/sdl/sdl.c
@@ -188,6 +188,15 @@ void sdl_display_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_colo
 
 }
 
+bool sdl_dis_drv_is_monitor_1(lv_disp_drv_t * disp_drv)
+{
+    return disp_drv->flush_cb == sdl_display_flush;
+}
+
+uint32_t monitor_1_win_id(void)
+{
+    return SDL_GetWindowID(monitor.window);
+}
 
 #if SDL_DUAL_DISPLAY
 
@@ -247,6 +256,17 @@ void sdl_display_flush2(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_col
     lv_disp_flush_ready(disp_drv);
 #endif
 }
+
+bool sdl_dis_drv_is_monitor_2(lv_disp_drv_t * disp_drv)
+{
+    return disp_drv->flush_cb == sdl_display_flush2;
+}
+
+uint32_t monitor_2_win_id(void)
+{
+    return SDL_GetWindowID(monitor2.window);
+}
+
 #endif
 
 /**********************

--- a/sdl/sdl_common_internal.h
+++ b/sdl/sdl_common_internal.h
@@ -30,6 +30,11 @@ void mousewheel_handler(SDL_Event * event);
 uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key);
 void keyboard_handler(SDL_Event * event);
 
+bool sdl_dis_drv_is_monitor_1(lv_disp_drv_t * disp_drv);
+bool sdl_dis_drv_is_monitor_2(lv_disp_drv_t * disp_drv);
+uint32_t monitor_1_win_id();
+uint32_t monitor_2_win_id();
+
 #endif /* USE_SDL || USE_SDL_GPU */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This change should fix having inputs for multiple displays. This new filtering also allows simulators to add additional non lvgl powered SDL windows that do not pollute the lvgl input data with their mouse presses.

If you set disp on your input driver to NULL it uses the default display (lvgl convention). If you actively set the display field the events will be bound to that SDL window.

In lvgl calling lv_disp_drv_register will automatically create the default display.

Example usage:

```
  lv_disp_t *disp = lv_disp_get_default();

  static lv_indev_drv_t indev_drv_mouse;
  lv_indev_drv_init( &indev_drv_mouse );
  indev_drv_mouse.disp = disp;
  indev_drv_mouse.type = LV_INDEV_TYPE_POINTER;
  indev_drv_mouse.read_cb = sdl_mouse_read;  /*This function will be called periodically (by the library) to get the mouse position and state*/
  lv_indev_drv_register( &indev_drv_mouse );
```